### PR TITLE
Ensure no public type is exposed

### DIFF
--- a/src/Polyfill/CompilerFeatureRequiredAttribute.cs
+++ b/src/Polyfill/CompilerFeatureRequiredAttribute.cs
@@ -16,7 +16,7 @@ namespace System.Runtime.CompilerServices;
     AttributeTargets.All,
     AllowMultiple = true,
     Inherited = false)]
-public sealed class CompilerFeatureRequiredAttribute : Attribute
+sealed class CompilerFeatureRequiredAttribute : Attribute
 {
     /// <summary>
     /// Initialize a new instance of <see cref="CompilerFeatureRequiredAttribute"/>

--- a/src/Tests/SanityChecks.cs
+++ b/src/Tests/SanityChecks.cs
@@ -1,0 +1,14 @@
+﻿[TestFixture]
+public class SanityChecks
+{
+    [Test]
+    public void NoPublicTypes()
+    {
+        var visibleTypes = typeof(SanityChecks).Assembly
+            .GetExportedTypes()
+            .Where(type => type.Namespace?.StartsWith("System") == true || type.Namespace == "Polyfill")
+            .ToList();
+
+        Assert.That(visibleTypes, Is.Empty);
+    }
+}


### PR DESCRIPTION
I noticed that `CompilerFeatureRequiredAttribute` is public.