### PR TITLE
Added `IEnumerable<TSource[]> Chunk<TSource> (this IEnumerable<TSource> source, int size)`, which was introduced in .NET 6

### DIFF
--- a/api_list.include.md
+++ b/api_list.include.md
@@ -10,7 +10,7 @@
 
 ### IEnumerable<TSource>
 
- * `IEnumerable<TSource[]> Chunk<TSource>(Int32)`
+ * `IEnumerable<TSource[]> Chunk<TSource>(Int32)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk)
  * `IEnumerable<TSource> Except<TSource>(TSource)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource[])` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource, IEqualityComparer<TSource>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))

--- a/api_list.include.md
+++ b/api_list.include.md
@@ -10,6 +10,7 @@
 
 ### IEnumerable<TSource>
 
+ * `IEnumerable<TSource[]> Chunk<TSource>(Int32)`
  * `IEnumerable<TSource> Except<TSource>(TSource)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource[])` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource, IEqualityComparer<TSource>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))

--- a/readme.md
+++ b/readme.md
@@ -359,7 +359,7 @@ The class `PolyfillExtensions` includes the following extension methods:
 
 ### IEnumerable<TSource>
 
- * `IEnumerable<TSource[]> Chunk<TSource>(Int32)`
+ * `IEnumerable<TSource[]> Chunk<TSource>(Int32)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk)
  * `IEnumerable<TSource> Except<TSource>(TSource)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource[])` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource, IEqualityComparer<TSource>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))

--- a/readme.md
+++ b/readme.md
@@ -359,6 +359,7 @@ The class `PolyfillExtensions` includes the following extension methods:
 
 ### IEnumerable<TSource>
 
+ * `IEnumerable<TSource[]> Chunk<TSource>(Int32)`
  * `IEnumerable<TSource> Except<TSource>(TSource)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource[])` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))
  * `IEnumerable<TSource> Except<TSource>(TSource, IEqualityComparer<TSource>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))))

--- a/src/Polyfill/PolyfillExtensions_IEnumerable.cs
+++ b/src/Polyfill/PolyfillExtensions_IEnumerable.cs
@@ -98,6 +98,7 @@ static partial class PolyfillExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1.</exception>
+    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk")]
     public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int size)
     {
         if (source is null)

--- a/src/Polyfill/PolyfillExtensions_IEnumerable.cs
+++ b/src/Polyfill/PolyfillExtensions_IEnumerable.cs
@@ -84,6 +84,92 @@ static partial class PolyfillExtensions
 #if NETSTANDARD || NETCOREAPP || NETFRAMEWORK || NET5_0
 
     /// <summary>
+    /// Split the elements of a sequence into chunks of size at most <paramref name="size"/>.
+    /// </summary>
+    /// <remarks>
+    /// Every chunk except the last will be of size <paramref name="size"/>.
+    /// The last chunk will contain the remaining elements and may be of a smaller size.
+    /// </remarks>
+    /// <param name="source">An <see cref="IEnumerable{T}"/> whose elements to chunk.</param>
+    /// <param name="size">Maximum size of each chunk.</param>
+    /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> that contains the elements the input sequence split into chunks of size <paramref name="size"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1.</exception>
+    public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int size)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (size < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), size, "Size must be greater than 0.");
+        }
+
+        return ChunkIterator(source, size);
+
+        static IEnumerable<TSource[]> ChunkIterator<TSource>(IEnumerable<TSource> source, int size)
+        {
+            using IEnumerator<TSource> e = source.GetEnumerator();
+
+            // Before allocating anything, make sure there's at least one element.
+            if (e.MoveNext())
+            {
+                // Now that we know we have at least one item, allocate an initial storage array. This is not
+                // the array we'll yield.  It starts out small in order to avoid significantly overallocating
+                // when the source has many fewer elements than the chunk size.
+                int arraySize = Math.Min(size, 4);
+                int i;
+                do
+                {
+                    var array = new TSource[arraySize];
+
+                    // Store the first item.
+                    array[0] = e.Current;
+                    i = 1;
+
+                    if (size != array.Length)
+                    {
+                        // This is the first chunk. As we fill the array, grow it as needed.
+                        for (; i < size && e.MoveNext(); i++)
+                        {
+                            if (i >= array.Length)
+                            {
+                                arraySize = (int)Math.Min((uint)size, 2 * (uint)array.Length);
+                                Array.Resize(ref array, arraySize);
+                            }
+
+                            array[i] = e.Current;
+                        }
+                    }
+                    else
+                    {
+                        // For all but the first chunk, the array will already be correctly sized.
+                        // We can just store into it until either it's full or MoveNext returns false.
+                        TSource[] local = array; // avoid bounds checks by using cached local (`array` is lifted to iterator object as a field)
+                        for (; (uint)i < (uint)local.Length && e.MoveNext(); i++)
+                        {
+                            local[i] = e.Current;
+                        }
+                    }
+
+                    if (i != array.Length)
+                    {
+                        Array.Resize(ref array, i);
+                    }
+
+                    yield return array;
+                }
+                while (i >= size && e.MoveNext());
+            }
+        }
+    }
+
+    /// <summary>
     /// Returns the maximum value in a generic sequence according to a specified key selector function.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>

--- a/src/Tests/PolyfillExtensionsTests_IEnumerable.cs
+++ b/src/Tests/PolyfillExtensionsTests_IEnumerable.cs
@@ -62,4 +62,20 @@ partial class PolyfillExtensionsTests
         Assert.AreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8 }, chunks[0]);
         Assert.AreEqual(new int[] { 9, 10, 11 }, chunks[1]);
     }
+
+    [Test]
+    public void Chunk_SizeOfZero_ExpectedException()
+    {
+        var enumerable = Enumerable.Range(1, 11).ToList();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => enumerable.Chunk(0).ToList());
+    }
+
+    [Test]
+    public void Chunk_Null_ExpectedException()
+    {
+        IEnumerable<int> values = null!;
+
+        Assert.Throws<ArgumentNullException>(() => values.Chunk(1).ToList());
+    }
 }

--- a/src/Tests/PolyfillExtensionsTests_IEnumerable.cs
+++ b/src/Tests/PolyfillExtensionsTests_IEnumerable.cs
@@ -34,8 +34,32 @@ partial class PolyfillExtensionsTests
     [Test]
     public void IEnumerableSkipLast()
     {
-        var enumerable = (IEnumerable<string>)new List<string> {"a", "b"};
+        var enumerable = (IEnumerable<string>)new List<string> { "a", "b" };
 
-        Assert.IsTrue(enumerable.SkipLast(1).SequenceEqual(new List<string> {"a"}));
+        Assert.IsTrue(enumerable.SkipLast(1).SequenceEqual(new List<string> { "a" }));
+    }
+
+    [Test]
+    public void Chunk_SizeOf3()
+    {
+        var enumerable = Enumerable.Range(1, 11).ToList();
+
+        var chunks = enumerable.Chunk(3).ToList();
+
+        Assert.AreEqual(new int[] { 1, 2, 3 }, chunks[0]);
+        Assert.AreEqual(new int[] { 4, 5, 6 }, chunks[1]);
+        Assert.AreEqual(new int[] { 7, 8, 9 }, chunks[2]);
+        Assert.AreEqual(new int[] { 10, 11 }, chunks[3]);
+    }
+
+    [Test]
+    public void Chunk_SizeOf8()
+    {
+        var enumerable = Enumerable.Range(1, 11).ToList();
+
+        var chunks = enumerable.Chunk(8).ToList();
+
+        Assert.AreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8 }, chunks[0]);
+        Assert.AreEqual(new int[] { 9, 10, 11 }, chunks[1]);
     }
 }


### PR DESCRIPTION
Added `IEnumerable<TSource[]> Chunk<TSource> (this IEnumerable<TSource> source, int size)`, which was introduced in .NET 6