### PR TITLE
fix: Added missing `ExcludeFromCodeCoverage` on nullability objects

### DIFF
--- a/src/Polyfill/Nullability/NullabilityInfo.cs
+++ b/src/Polyfill/Nullability/NullabilityInfo.cs
@@ -9,16 +9,18 @@ using System.Linq;
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {
     /// <summary>
     /// A class that represents nullability info
     /// </summary>
-    #if PolyPublic
+    [ExcludeFromCodeCoverage]
+#if PolyPublic
 public
 #endif
-sealed class NullabilityInfo
+    sealed class NullabilityInfo
     {
         internal NullabilityInfo(Type type, NullabilityState readState, NullabilityState writeState,
             NullabilityInfo? elementType, NullabilityInfo[] typeArguments)

--- a/src/Polyfill/Nullability/NullabilityInfoContext.cs
+++ b/src/Polyfill/Nullability/NullabilityInfoContext.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {
@@ -18,10 +19,11 @@ namespace System.Reflection
     /// Provides APIs for populating nullability information/context from reflection members:
     /// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.
     /// </summary>
-    #if PolyPublic
+    [ExcludeFromCodeCoverage]
+#if PolyPublic
 public
 #endif
-sealed class NullabilityInfoContext
+    sealed class NullabilityInfoContext
     {
         private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
         private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = new();
@@ -632,6 +634,7 @@ sealed class NullabilityInfoContext
         private static bool IsValueTypeOrValueTypeByRef(Type type) =>
             type.IsValueType || ((type.IsByRef || type.IsPointer) && type.GetElementType()!.IsValueType);
 
+        [ExcludeFromCodeCoverage]
         private readonly struct NullableAttributeStateParser
         {
             private static readonly object UnknownByte = (byte)0;


### PR DESCRIPTION
to reduce the code coverage impact, when Polyfill is used.