### PR TITLE
Fix Task.WaitAsync bug

### DIFF
--- a/api_list.include.md
+++ b/api_list.include.md
@@ -235,7 +235,7 @@
 ### Task<TResult>
 
  * `Task<TResult> WaitAsync<TResult>(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken))
- * `Task<TResult> WaitAsync<TResult>(TimeSpan)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-threading-cancellationtoken))
+ * `Task<TResult> WaitAsync<TResult>(TimeSpan)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan))
  * `Task<TResult> WaitAsync<TResult>(TimeSpan, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan-system-threading-cancellationtoken))
 
 

--- a/readme.md
+++ b/readme.md
@@ -590,7 +590,7 @@ The class `PolyfillExtensions` includes the following extension methods:
 ### Task<TResult>
 
  * `Task<TResult> WaitAsync<TResult>(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken))
- * `Task<TResult> WaitAsync<TResult>(TimeSpan)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-threading-cancellationtoken))
+ * `Task<TResult> WaitAsync<TResult>(TimeSpan)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan))
  * `Task<TResult> WaitAsync<TResult>(TimeSpan, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan-system-threading-cancellationtoken))
 
 

--- a/src/Polyfill/PolyfillExtensions_Memory.cs
+++ b/src/Polyfill/PolyfillExtensions_Memory.cs
@@ -16,7 +16,7 @@ static partial class PolyfillExtensions
     /// Indicates whether a specified value is found in a read-only span. Values are compared using IEquatable{T}.Equals(T).
     /// </summary>
     /// <param name="value">The value to search for.</param>
-    /// <returns>true if found, false otherwise.</returns>
+    /// <returns><c>true</c> if found, <c>false</c> otherwise.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.contains#system-memoryextensions-contains-1(system-readonlyspan((-0))-0)")]
     public static bool Contains<T>(
         this ReadOnlySpan<T> target,
@@ -38,7 +38,7 @@ static partial class PolyfillExtensions
     /// Indicates whether a specified value is found in a only span. Values are compared using IEquatable{T}.Equals(T).
     /// </summary>
     /// <param name="value">The value to search for.</param>
-    /// <returns>true if found, false otherwise.</returns>
+    /// <returns><c>true</c> if found, <c>false</c> otherwise.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.contains#system-memoryextensions-contains-1(system-span((-0))-0)")]
     public static bool Contains<T>(
         this Span<T> target,
@@ -56,18 +56,37 @@ static partial class PolyfillExtensions
         return false;
     }
 
+    /// <summary>
+    /// Determines whether two sequences are equal by comparing the elements using IEquatable{T}.Equals(T).
+    /// </summary>
+    /// <param name="target">The first sequence to compare.</param>
+    /// <param name="other">The second sequence to compare.</param>
+    /// <returns><c>true</c> if the two sequences are equal; otherwise, <c>false</c>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequenceequal#system-memoryextensions-sequenceequal-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
     public static bool SequenceEqual(
         this ReadOnlySpan<char> target,
         string other) =>
         target.SequenceEqual(other.AsSpan());
 
+    /// <summary>
+    /// Determines whether two sequences are equal by comparing the elements using IEquatable{T}.Equals(T).
+    /// </summary>
+    /// <param name="target">The first sequence to compare.</param>
+    /// <param name="other">The second sequence to compare.</param>
+    /// <returns><c>true</c> if the two sequences are equal; otherwise, <c>false</c>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequenceequal#system-memoryextensions-sequenceequal-1(system-span((-0))-system-readonlyspan((-0)))")]
     public static bool SequenceEqual(
         this Span<char> target,
         string other) =>
         target.SequenceEqual(other.AsSpan());
 
+    /// <summary>
+    /// Determines whether a read-only character span begins with a specified value when compared using a specified <see cref="StringComparison"/> value.
+    /// </summary>
+    /// <param name="target">The source span.</param>
+    /// <param name="other">The sequence to compare to the beginning of the source span.</param>
+    /// <param name="comparison">An enumeration value that determines how span and value are compared.</param>
+    /// <returns><c>true</c> if value matches the beginning of span; otherwise, <c>false</c>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.startswith#system-memoryextensions-startswith-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
     public static bool StartsWith(
         this ReadOnlySpan<char> target,
@@ -75,12 +94,25 @@ static partial class PolyfillExtensions
         StringComparison comparison = StringComparison.CurrentCulture) =>
         target.StartsWith(other.AsSpan(), comparison);
 
+    /// <summary>
+    /// Determines whether a specified sequence appears at the start of a span.
+    /// </summary>
+    /// <param name="target">The source span.</param>
+    /// <param name="other">The sequence to compare to the beginning of the source span.</param>
+    /// <returns><c>true</c> if value matches the beginning of span; otherwise, <c>false</c>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.startswith#system-memoryextensions-startswith-1(system-span((-0))-system-readonlyspan((-0)))")]
     public static bool StartsWith(
         this Span<char> target,
         string other) =>
         target.StartsWith(other.AsSpan());
 
+    /// <summary>
+    /// Determines whether the end of the span matches the specified value when compared using the specified <paramref name="comparison"/> option.
+    /// </summary>
+    /// <param name="target">The source span.</param>
+    /// <param name="other">The sequence to compare to the end of the source span.</param>
+    /// <param name="comparison">An enumeration value that determines how span and value are compared.</param>
+    /// <returns><c>true</c> if value matches the end of span; otherwise, <c>false</c>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
     public static bool EndsWith(
         this ReadOnlySpan<char> target,
@@ -88,10 +120,17 @@ static partial class PolyfillExtensions
         StringComparison comparison = StringComparison.CurrentCulture) =>
         target.EndsWith(other.AsSpan(), comparison);
 
+    /// <summary>
+    /// Determines whether the specified sequence appears at the end of a span.
+    /// </summary>
+    /// <param name="target">The source span.</param>
+    /// <param name="other">The sequence to compare to the end of the source span.</param>
+    /// <returns><c>true</c> if value matches the end of span; otherwise, <c>false</c>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-span((-0))-system-readonlyspan((-0)))")]
     public static bool EndsWith(
         this Span<char> target,
         string other) =>
         target.EndsWith(other.AsSpan());
 }
+
 #endif

--- a/src/Polyfill/PolyfillExtensions_Task.cs
+++ b/src/Polyfill/PolyfillExtensions_Task.cs
@@ -12,80 +12,116 @@ using Link = System.ComponentModel.DescriptionAttribute;
 
 static partial class PolyfillExtensions
 {
+    // Copied from .NET library const Timer.MaxSupportedTimeout
+    private const uint MaxSupportedTimeout = 0xfffffffe;
+
+    /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken)")]
     public static Task WaitAsync(this Task target, CancellationToken cancellationToken) =>
         target.WaitAsync(Timeout.InfiniteTimeSpan, cancellationToken);
 
+    /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified timeout expires.</summary>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-timespan)")]
-    public static async Task WaitAsync(
+    public static Task WaitAsync(
         this Task target,
-        TimeSpan timeout)
-    {
-        var cancelSource = new CancellationTokenSource();
-        try
-        {
-            await target.WaitAsync(timeout, cancelSource.Token);
-        }
-        finally
-        {
-            cancelSource.Cancel();
-            cancelSource.Dispose();
-        }
-    }
+        TimeSpan timeout) =>
+        target.WaitAsync(timeout, default);
 
+    /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, when the specified timeout expires, or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-timespan-system-threading-cancellationtoken)")]
-    public static async Task WaitAsync(
+    public static Task WaitAsync(
         this Task target,
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
-        var delayTask = Task.Delay(timeout, cancellationToken);
-        var completedTask = await Task.WhenAny(target, delayTask);
-        if (completedTask == delayTask)
+        if (target is null)
         {
-            throw new TimeoutException($"Execution did not complete within the time allotted {timeout.TotalMilliseconds} ms");
+            throw new ArgumentNullException(nameof(target));
         }
 
-        await target;
+        long totalMilliseconds = (long)timeout.TotalMilliseconds;
+        if (totalMilliseconds < -1 || totalMilliseconds > MaxSupportedTimeout)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+        if (target.IsCompleted || (!cancellationToken.CanBeCanceled && timeout == Timeout.InfiniteTimeSpan))
+        {
+            return target;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return Task.FromException(new TimeoutException());
+        }
+
+        var delayTask = Task.Delay(timeout, cancellationToken);
+
+        Func<Task<Task>, Task> continueFunc = completedTask =>
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new TaskCanceledException();
+            }
+            else if (completedTask.Result == delayTask)
+            {
+                throw new TimeoutException($"Execution did not complete within the time allotted {timeout.TotalMilliseconds} ms");
+            }
+
+            return target;
+        };
+
+        return Task.WhenAny(target, delayTask).ContinueWith(continueFunc, TaskContinuationOptions.OnlyOnRanToCompletion);
     }
 
+    /// <summary>
+    /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, or when the specified <see cref="CancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken)")]
     public static Task<TResult> WaitAsync<TResult>(
         this Task<TResult> target,
         CancellationToken cancellationToken) =>
         target.WaitAsync<TResult>(Timeout.InfiniteTimeSpan, cancellationToken);
 
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-threading-cancellationtoken)")]
-    public static async Task<TResult> WaitAsync<TResult>(
+    /// <summary>
+    /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, or when the specified timeout expires.
+    /// </summary>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
+    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan)")]
+    public static Task<TResult> WaitAsync<TResult>(
         this Task<TResult> target,
-        TimeSpan timeout)
-    {
-        var cancelSource = new CancellationTokenSource();
-        try
-        {
-            return await target.WaitAsync(timeout, cancelSource.Token);
-        }
-        finally
-        {
-            cancelSource.Cancel();
-            cancelSource.Dispose();
-        }
-    }
+        TimeSpan timeout) =>
+        target.WaitAsync<TResult>(timeout, default);
 
+    /// <summary>
+    /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, when the specified timeout expires, or when the specified <see cref="CancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan-system-threading-cancellationtoken)")]
     public static async Task<TResult> WaitAsync<TResult>(
         this Task<TResult> target,
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
-        var delayTask = Task.Delay(timeout, cancellationToken);
-        var completedTask = await Task.WhenAny(target, delayTask);
-        if (completedTask == delayTask)
-        {
-            throw new TimeoutException($"Execution did not complete within the time allotted {timeout.TotalMilliseconds} ms");
-        }
-
-        return await target;
+        await ((Task)target).WaitAsync(timeout, cancellationToken);
+        return target.Result;
     }
 }
 

--- a/src/Tests/PolyfillExtensionsTests_Memory.cs
+++ b/src/Tests/PolyfillExtensionsTests_Memory.cs
@@ -1,15 +1,245 @@
 partial class PolyfillExtensionsTests
 {
     [Test]
-    public void SpanContains()
+    public void ReadOnlySpan_ZeroLengthContains()
     {
-        Assert.True("value".AsSpan().Contains('e'));
-        var span = new Span<char>("value".ToCharArray());
-        Assert.True(span.Contains('e'));
+        ReadOnlySpan<int> span = new ReadOnlySpan<int>(Array.Empty<int>());
+
+        bool found = span.Contains(0);
+        Assert.False(found);
     }
 
     [Test]
-    public void SpanSequenceEqual()
+    public void ReadOnlySpan_TestContains()
+    {
+        for (int length = 0; length < 32; length++)
+        {
+            int[] a = new int[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = 10 * (i + 1);
+            }
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(a);
+
+            for (int targetIndex = 0; targetIndex < length; targetIndex++)
+            {
+                int target = a[targetIndex];
+                bool found = span.Contains(target);
+                Assert.True(found);
+            }
+        }
+    }
+
+    [Test]
+    public void ReadOnlySpan_TestMultipleContains()
+    {
+        for (int length = 2; length < 32; length++)
+        {
+            int[] a = new int[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = 10 * (i + 1);
+            }
+
+            a[length - 1] = 5555;
+            a[length - 2] = 5555;
+
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(a);
+            bool found = span.Contains(5555);
+            Assert.True(found);
+        }
+    }
+
+    [Test]
+    public void ReadOnlySpan_ZeroLengthContains_String()
+    {
+        ReadOnlySpan<string> span = new ReadOnlySpan<string>(Array.Empty<string>());
+        bool found = span.Contains("a");
+        Assert.False(found);
+    }
+
+    [Test]
+    public void ReadOnlySpan_TestMatchContains_String()
+    {
+        for (int length = 0; length < 32; length++)
+        {
+            string[] a = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = (10 * (i + 1)).ToString();
+            }
+            ReadOnlySpan<string> span = new ReadOnlySpan<string>(a);
+
+            for (int targetIndex = 0; targetIndex < length; targetIndex++)
+            {
+                string target = a[targetIndex];
+                bool found = span.Contains(target);
+                Assert.True(found);
+            }
+        }
+    }
+
+    [Test]
+    public void ReadOnlySpan_TestNoMatchContains_String()
+    {
+        var rnd = new Random(42);
+        for (int length = 0; length <= byte.MaxValue; length++)
+        {
+            string[] a = new string[length];
+            string target = (rnd.Next(0, 256)).ToString();
+            for (int i = 0; i < length; i++)
+            {
+                string val = (i + 1).ToString();
+                a[i] = val == target ? (target + 1) : val;
+            }
+            ReadOnlySpan<string> span = new ReadOnlySpan<string>(a);
+
+            bool found = span.Contains(target);
+            Assert.False(found);
+        }
+    }
+
+    [Test]
+    public void ReadOnlySpan_TestMultipleMatchContains_String()
+    {
+        for (int length = 2; length < 32; length++)
+        {
+            string[] a = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = (10 * (i + 1)).ToString();
+            }
+
+            a[length - 1] = "5555";
+            a[length - 2] = "5555";
+
+            ReadOnlySpan<string> span = new ReadOnlySpan<string>(a);
+            bool found = span.Contains("5555");
+            Assert.True(found);
+        }
+    }
+
+    [Test]
+    public void Span_ZeroLengthContains()
+    {
+        Span<int> span = new Span<int>(Array.Empty<int>());
+
+        bool found = span.Contains(0);
+        Assert.False(found);
+    }
+
+    [Test]
+    public void Span_TestContains()
+    {
+        for (int length = 0; length < 32; length++)
+        {
+            int[] a = new int[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = 10 * (i + 1);
+            }
+            Span<int> span = new Span<int>(a);
+
+            for (int targetIndex = 0; targetIndex < length; targetIndex++)
+            {
+                int target = a[targetIndex];
+                bool found = span.Contains(target);
+                Assert.True(found);
+            }
+        }
+    }
+
+    [Test]
+    public void Span_TestMultipleContains()
+    {
+        for (int length = 2; length < 32; length++)
+        {
+            int[] a = new int[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = 10 * (i + 1);
+            }
+
+            a[length - 1] = 5555;
+            a[length - 2] = 5555;
+
+            Span<int> span = new Span<int>(a);
+            bool found = span.Contains(5555);
+            Assert.True(found);
+        }
+    }
+
+    [Test]
+    public void Span_ZeroLengthContains_String()
+    {
+        Span<string> span = new Span<string>(Array.Empty<string>());
+        bool found = span.Contains("a");
+        Assert.False(found);
+    }
+
+    [Test]
+    public void Span_TestMatchContains_String()
+    {
+        for (int length = 0; length < 32; length++)
+        {
+            string[] a = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = (10 * (i + 1)).ToString();
+            }
+            Span<string> span = new Span<string>(a);
+
+            for (int targetIndex = 0; targetIndex < length; targetIndex++)
+            {
+                string target = a[targetIndex];
+                bool found = span.Contains(target);
+                Assert.True(found);
+            }
+        }
+    }
+
+    [Test]
+    public void Span_TestNoMatchContains_String()
+    {
+        var rnd = new Random(42);
+        for (int length = 0; length <= byte.MaxValue; length++)
+        {
+            string[] a = new string[length];
+            string target = (rnd.Next(0, 256)).ToString();
+            for (int i = 0; i < length; i++)
+            {
+                string val = (i + 1).ToString();
+                a[i] = val == target ? (target + 1) : val;
+            }
+            Span<string> span = new Span<string>(a);
+
+            bool found = span.Contains(target);
+            Assert.False(found);
+        }
+    }
+
+    [Test]
+    public void Span_TestMultipleMatchContains_String()
+    {
+        for (int length = 2; length < 32; length++)
+        {
+            string[] a = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                a[i] = (10 * (i + 1)).ToString();
+            }
+
+            a[length - 1] = "5555";
+            a[length - 2] = "5555";
+
+            Span<string> span = new Span<string>(a);
+            bool found = span.Contains("5555");
+            Assert.True(found);
+        }
+    }
+
+    [Test]
+    public void Span_SequenceEqual()
     {
         Assert.True("value".AsSpan().SequenceEqual("value"));
         Assert.False("value".AsSpan().SequenceEqual("value2"));
@@ -21,7 +251,7 @@ partial class PolyfillExtensionsTests
     }
 
     [Test]
-    public void SpanStartsWith()
+    public void Span_StartsWith()
     {
         Assert.True("value".AsSpan().StartsWith("value"));
         Assert.False("value".AsSpan().StartsWith("value2"));
@@ -33,7 +263,7 @@ partial class PolyfillExtensionsTests
     }
 
     [Test]
-    public void SpanEndsWith()
+    public void Span_EndsWith()
     {
         Assert.True("value".AsSpan().EndsWith("value"));
         Assert.False("value".AsSpan().EndsWith("value2"));

--- a/src/Tests/PolyfillExtensionsTests_Task.cs
+++ b/src/Tests/PolyfillExtensionsTests_Task.cs
@@ -1,0 +1,131 @@
+partial class PolyfillExtensionsTests
+{
+    private static T? AssertThrowsAsync<T>(string expectedParamName, AsyncTestDelegate action)
+        where T : ArgumentException
+    {
+        T? exception = Assert.ThrowsAsync<T>(action);
+
+        Assert.AreEqual(expectedParamName, exception?.ParamName);
+
+        return exception;
+    }
+
+    [Test]
+    public void Task_WaitAsync_InvalidTimeout_Throws()
+    {
+        foreach (TimeSpan timeout in new[] { TimeSpan.FromMilliseconds(-2), TimeSpan.MaxValue, TimeSpan.MinValue })
+        {
+#if NET5_0_OR_GREATER
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await new TaskCompletionSource().Task.WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await new TaskCompletionSource().Task.WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await new TaskCompletionSource().Task.WaitAsync(timeout, new CancellationToken(true)));
+#endif
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await new TaskCompletionSource<int>().Task.WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await new TaskCompletionSource<int>().Task.WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await new TaskCompletionSource<int>().Task.WaitAsync(timeout, new CancellationToken(true)));
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.CompletedTask.WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.CompletedTask.WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.CompletedTask.WaitAsync(timeout, new CancellationToken(true)));
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromResult(42).WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromResult(42).WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromResult(42).WaitAsync(timeout, new CancellationToken(true)));
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromCanceled(new CancellationToken(true)).WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromCanceled(new CancellationToken(true)).WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromCanceled(new CancellationToken(true)).WaitAsync(timeout, new CancellationToken(true)));
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromCanceled<int>(new CancellationToken(true)).WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromCanceled<int>(new CancellationToken(true)).WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromCanceled<int>(new CancellationToken(true)).WaitAsync(timeout, new CancellationToken(true)));
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromException(new FormatException()).WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromException(new FormatException()).WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromException(new FormatException()).WaitAsync(timeout, new CancellationToken(true)));
+
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromException<int>(new FormatException()).WaitAsync(timeout));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromException<int>(new FormatException()).WaitAsync(timeout, CancellationToken.None));
+            AssertThrowsAsync<ArgumentOutOfRangeException>("timeout", async () => await Task.FromException<int>(new FormatException()).WaitAsync(timeout, new CancellationToken(true)));
+        }
+    }
+
+    [Test]
+    public async Task Task_WaitAsync_CanceledAndTimedOut_AlreadyCompleted_UsesTaskResult()
+    {
+        await Task.CompletedTask.WaitAsync(TimeSpan.Zero);
+        await Task.CompletedTask.WaitAsync(new CancellationToken(true));
+        await Task.CompletedTask.WaitAsync(TimeSpan.Zero, new CancellationToken(true));
+
+        Assert.AreEqual(42, await Task.FromResult(42).WaitAsync(TimeSpan.Zero));
+        Assert.AreEqual(42, await Task.FromResult(42).WaitAsync(new CancellationToken(true)));
+        Assert.AreEqual(42, await Task.FromResult(42).WaitAsync(TimeSpan.Zero, new CancellationToken(true)));
+
+        Assert.ThrowsAsync<FormatException>(async () => await Task.FromException(new FormatException()).WaitAsync(TimeSpan.Zero));
+        Assert.ThrowsAsync<FormatException>(async () => await Task.FromException(new FormatException()).WaitAsync(new CancellationToken(true)));
+        Assert.ThrowsAsync<FormatException>(async () => await Task.FromException(new FormatException()).WaitAsync(TimeSpan.Zero, new CancellationToken(true)));
+
+        Assert.ThrowsAsync<FormatException>(async () => await Task.FromException<int>(new FormatException()).WaitAsync(TimeSpan.Zero));
+        Assert.ThrowsAsync<FormatException>(async () => await Task.FromException<int>(new FormatException()).WaitAsync(new CancellationToken(true)));
+        Assert.ThrowsAsync<FormatException>(async () => await Task.FromException<int>(new FormatException()).WaitAsync(TimeSpan.Zero, new CancellationToken(true)));
+
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.FromCanceled(new CancellationToken(true)).WaitAsync(TimeSpan.Zero));
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.FromCanceled(new CancellationToken(true)).WaitAsync(new CancellationToken(true)));
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.FromCanceled(new CancellationToken(true)).WaitAsync(TimeSpan.Zero, new CancellationToken(true)));
+
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.FromCanceled<int>(new CancellationToken(true)).WaitAsync(TimeSpan.Zero));
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.FromCanceled<int>(new CancellationToken(true)).WaitAsync(new CancellationToken(true)));
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.FromCanceled<int>(new CancellationToken(true)).WaitAsync(TimeSpan.Zero, new CancellationToken(true)));
+    }
+
+    [Test]
+    public void Task_WaitAsync_TimeoutOrCanceled_Throws()
+    {
+        var tcs = new TaskCompletionSource<int>();
+        var cts = new CancellationTokenSource();
+
+        Assert.ThrowsAsync<TimeoutException>(async () => await ((Task)tcs.Task).WaitAsync(TimeSpan.Zero));
+        Assert.ThrowsAsync<TimeoutException>(async () => await ((Task)tcs.Task).WaitAsync(TimeSpan.FromMilliseconds(1)));
+        Assert.ThrowsAsync<TimeoutException>(async () => await ((Task)tcs.Task).WaitAsync(TimeSpan.FromMilliseconds(1), cts.Token));
+
+        Assert.ThrowsAsync<TimeoutException>(async () => await tcs.Task.WaitAsync(TimeSpan.Zero));
+        Assert.ThrowsAsync<TimeoutException>(async () => await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(1)));
+        Assert.ThrowsAsync<TimeoutException>(async () => await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(1), cts.Token));
+
+        Task assert1 = ((Task)tcs.Task).WaitAsync(cts.Token);
+        Task assert2 = ((Task)tcs.Task).WaitAsync(Timeout.InfiniteTimeSpan, cts.Token);
+        Task assert3 = tcs.Task.WaitAsync(cts.Token);
+        Task assert4 = tcs.Task.WaitAsync(Timeout.InfiniteTimeSpan, cts.Token);
+        Assert.False(assert1.IsCompleted);
+        Assert.False(assert2.IsCompleted);
+        Assert.False(assert3.IsCompleted);
+        Assert.False(assert4.IsCompleted);
+
+        cts.Cancel();
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await assert1);
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await assert2);
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await assert3);
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await assert4);
+    }
+
+    [Test]
+    public async Task Task_WaitAsync_NoCancellationOrTimeoutOccurs_Success()
+    {
+        CancellationTokenSource cts = new CancellationTokenSource();
+
+#if NET5_0_OR_GREATER
+        var tcs = new TaskCompletionSource();
+        Task t = tcs.Task.WaitAsync(TimeSpan.FromDays(1), cts.Token);
+        Assert.False(t.IsCompleted);
+        tcs.SetResult();
+        await t;
+#endif
+
+        var tcsg = new TaskCompletionSource<int>();
+        Task<int> tg = tcsg.Task.WaitAsync(TimeSpan.FromDays(1), cts.Token);
+        Assert.False(tg.IsCompleted);
+        tcsg.SetResult(42);
+        Assert.AreEqual(42, await tg);
+    }
+}


### PR DESCRIPTION
Small PR that adds doc comments to some existing extension methods that were missing doc comments before, and expands the tests for the methods where doc comments were added.

Doc comments and tests were taken from .NET source and slightly modified to fit this repo.

After adding the tests for `Task.WaitAsync`, it became clear that Polyfill's implementation differed in logic slightly from the .NET implementation as some of the tests I copied from the .NET source failed when run in Polyfill's test suite. So I updated the Polyfill `Task.WaitAsync` implementation to act more like the .NET implementation.