### PR TITLE
Add workarounds for legacy-style projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The default type visibility for all polyfills is `internal`. This means it can b
 
 ### Consuming in an app
 
-If Polyfill is being consumed in a solution that produce an app, then it is recommended to use the Polyfill nuget only in the root "app project" and enable `PolyPublic`.
+If Polyfill is being consumed in a solution that produces an app, then it is recommended to use the Polyfill nuget only in the root "app project" and enable `PolyPublic`.
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -65,9 +65,25 @@ Then all consuming projects, like tests, will not need to use the Polyfill nuget
 
 ### Consuming in a library
 
-If Polyfill is being consumed in a solution that produce a library (and usually a nuget), then the Polyfill nuget can be added to all projects.
+If Polyfill is being consumed in a solution that produces a library (and usually a nuget), then the Polyfill nuget can be added to all projects.
 
 If, however, `InternalsVisibileTo` is being used to expose APIs (for example to test projects), then the Polyfill nuget should be added only to the root library project.
+
+
+### Consuming in a legacy-style projects
+
+If Polyfill is being consumed in a legacy-style project that cannot be migrated to SDK-style projects (for example legacy ASP.NET apps), then an additional constant must be set in the legacy project.
+
+```xml
+<DefineConstants>NETFRAMEWORK</DefineConstants>
+```
+
+If constants are already being set (for example for build configurations), then append `;NETFRAMEWORK` to the constants for each build configuration's existing constants.
+
+```xml
+<DefineConstants>TRACE;NETFRAMEWORK</DefineConstants>
+```
+
 
 
 ## Included polyfills

--- a/src/Polyfill/Polyfill.props
+++ b/src/Polyfill/Polyfill.props
@@ -2,6 +2,24 @@
   <PropertyGroup Condition="$(AllowUnsafeBlocks) == 'true' ">
     <DefineConstants>$(DefineConstants);AllowUnsafeBlocks</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworkVersion)' == 'v4.6.1'">
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworkVersion)' == 'v4.6.2'">
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworkVersion)' == 'v4.7'">
+    <TargetFramework>net47</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworkVersion)' == 'v4.7.1'">
+    <TargetFramework>net471</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworkVersion)' == 'v4.7.2'">
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworkVersion)' == 'v4.8'">
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
   <PropertyGroup>
     <ValueTupleReferenced>false</ValueTupleReferenced>
     <MemoryReferenced>false</MemoryReferenced>

--- a/src/Polyfill/Polyfill.targets
+++ b/src/Polyfill/Polyfill.targets
@@ -6,6 +6,16 @@
     <DefineConstants>$(DefineConstants);PolyPublic</DefineConstants>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<ResolvePackageAssetsTargets Condition="Exists($(ResolvePackageAssets))">true</ResolvePackageAssetsTargets>
+	</PropertyGroup>
+
+	<Target Name="ResolvePackageAssets"
+			Condition="'$(ResolvePackageAssetsTargets)' != 'true'"
+			AfterTargets="ResolveReferences">
+		<Message Importance="normal" Text="ResolvePackageAssets target doesn't exist. Adding a placeholder." />
+	</Target>
+
   <Target Name="PreparePolyfill" DependsOnTargets="ResolvePackageAssets">
     <PropertyGroup>
       <ValueTupleReferenced


### PR DESCRIPTION
Adding workarounds for supporting legacy-style projects (see #101).

The workarounds consist of two parts

1. Attempts to detect a legacy-style project (`TargetFramework` property is not set, but `TargetFrameworkVersion` is) and adds the relevant `TargetFramework` property.
2. Adds a dummy `ResolvePackageAssets` target if it is not already defined (as is the case when MSBuild builds for legacy-style projects; `ResolvePackageAssets` is part of the dotnet SDK)

Checks for `TargetFrameworkVersion` `v4.8.1` to add the `net481` target framework moniker weren't included because according to https://learn.microsoft.com/en-us/dotnet/standard/frameworks they don't officially exist.

Documentation updated to include direction to add `NETFRAMEWORK` preprocessor constant in the legacy-style project(s).