### PR TITLE
Fix bad XML causing Except function doc comments to not work

### DIFF
--- a/src/Polyfill/PolyfillExtensions_IEnumerable.cs
+++ b/src/Polyfill/PolyfillExtensions_IEnumerable.cs
@@ -12,7 +12,7 @@ static partial class PolyfillExtensions
     /// <summary>
     /// Produces a set items excluding <paramref name="item"/> by using the default equality comparer to compare values.
     /// </summary>
-    /// <param name="target">An <see cref="IEnumerable<TSource>"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
+    /// <param name="target">An <see cref="IEnumerable&lt;TSource&gt;"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
     /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
@@ -25,7 +25,7 @@ static partial class PolyfillExtensions
     /// <summary>
     /// Produces the set difference of two sequences by using the default equality comparer to compare values.
     /// </summary>
-    /// <param name="target">An <see cref="IEnumerable<TSource>"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
+    /// <param name="target">An <see cref="IEnumerable&lt;TSource&gt;"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
     /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
@@ -38,9 +38,9 @@ static partial class PolyfillExtensions
     /// <summary>
     /// Produces a set items excluding <paramref name="item"/> by using <paramref name="comparer"/> to compare values.
     /// </summary>
-    /// <param name="target">An <see cref="IEnumerable<TSource>"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
+    /// <param name="target">An <see cref="IEnumerable&lt;TSource&gt;"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
     /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
-    /// <param name="comparer">An <see cref="IEqualityComparer<TSource>"/> to compare values.</param>
+    /// <param name="comparer">An <see cref="IEqualityComparer&lt;TSource&gt;"/> to compare values.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))")]
@@ -63,7 +63,7 @@ static partial class PolyfillExtensions
     /// <summary>
     /// Produces the set difference of two sequences by <paramref name="comparer"/> to compare values.
     /// </summary>
-    /// <param name="target">An <see cref="IEnumerable<TSource>"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
+    /// <param name="target">An <see cref="IEnumerable&lt;TSource&gt;"/> whose elements that are not equal to <paramref name="item"/> will be returned.</param>
     /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>


### PR DESCRIPTION
Some incorrect XML was causing doc comments for the `Except` functions to not show up at all in IDEs and causing the following to output into doc XML files of downstream projects:
```
<!-- Badly formed XML comment ignored for member "M:PolyfillExtensions.Except``1(System.Collections.Generic.IEnumerable{``0},``0)" -->
<!-- Badly formed XML comment ignored for member "M:PolyfillExtensions.Except``1(System.Collections.Generic.IEnumerable{``0},``0[])" -->
<!-- Badly formed XML comment ignored for member "M:PolyfillExtensions.Except``1(System.Collections.Generic.IEnumerable{``0},``0,System.Collections.Generic.IEqualityComparer{``0})" -->
<!-- Badly formed XML comment ignored for member "M:PolyfillExtensions.Except``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0},``0[])" -->
```

This PR fixes the XML so that it works correctly.