### PR TITLE
Fix some compiler errors that can occur with specific project setups (Debug references)

### DIFF
--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -98,6 +98,10 @@ class Consume
         var split = "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries);
         split = "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
         var contains = "a b".Contains(' ');
+
+        // Test to make sure there are no clashes in the Polyfill code with classes that
+        // might be defined in user code. See comments in Debug.cs for more details.
+        Debug.Log("Test log to make sure this is working");
     }
 
 #if HTTPREFERENCED

--- a/src/Consume/Debug.cs
+++ b/src/Consume/Debug.cs
@@ -1,0 +1,29 @@
+using System;
+
+// Test to make sure there are no clashes in the Polyfill code with classes that might be defined in user code.
+//
+// Some codebases, for better or for worse, define classes with names that match common classes in the base
+// .NET libraries, like "Debug". This works find in those codebases because they are usually contained in the
+// same namespace, or are guarded in some other way. But if a Polyfill attribute is imported and uses code like:
+//     Debug.Assert(genericParameter.IsGenericParameter);
+// instead of a fully qualified name like:
+//     System.Debug.Assert(genericParameter.IsGenericParameter);
+// then users of Polyfill will get errors like the following, which they can't easily fix:
+//     'Debug' does not contain a definition for 'Assert'
+//
+// So, this file defines a custom Debug class to make sure that Polyfill code doesn't clash with user code.
+
+class Debug
+{
+    public static void Log(string content) => Console.WriteLine(content);
+
+    public static void Log(ConsoleColor color, string content)
+    {
+        Console.ForegroundColor = color;
+        Console.WriteLine(content);
+        Console.ResetColor();
+    }
+
+    public static void LogWarning(string content) => Log(ConsoleColor.Yellow, content);
+    public static void LogError(string content) => Log(ConsoleColor.Red, content);
+}

--- a/src/Polyfill/Nullability/NullabilityInfo.cs
+++ b/src/Polyfill/Nullability/NullabilityInfo.cs
@@ -6,6 +6,7 @@
 
 using System.Linq;
 using System.Diagnostics.CodeAnalysis;
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/src/Polyfill/Nullability/NullabilityInfoContext.cs
+++ b/src/Polyfill/Nullability/NullabilityInfoContext.cs
@@ -6,6 +6,7 @@
 
 using System.Linq;
 using System.Diagnostics.CodeAnalysis;
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -15,6 +16,10 @@ using System.Diagnostics;
 
 namespace System.Reflection
 {
+    // Some codebases define their own Debug class, which can cause clashes and compile errors if we aren't explicit here.
+    // See comments in Debug.cs in Consume project for more details.
+    using Debug = System.Diagnostics.Debug;
+
     /// <summary>
     /// Provides APIs for populating nullability information/context from reflection members:
     /// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.

--- a/src/Polyfill/StringInterpolation/AppendInterpolatedStringHandler.cs
+++ b/src/Polyfill/StringInterpolation/AppendInterpolatedStringHandler.cs
@@ -10,6 +10,10 @@ using System.Runtime.CompilerServices;
 
 namespace System.Text;
 
+// Some codebases define their own Debug class, which can cause clashes and compile errors if we aren't explicit here.
+// See comments in Debug.cs in Consume project for more details.
+using Debug = System.Diagnostics.Debug;
+
 /// <summary>Provides a handler used by the language compiler to append interpolated strings into <see cref="StringBuilder"/> instances.</summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 [InterpolatedStringHandler]

--- a/src/Polyfill/StringInterpolation/DefaultInterpolatedStringHandler.cs
+++ b/src/Polyfill/StringInterpolation/DefaultInterpolatedStringHandler.cs
@@ -14,6 +14,10 @@ using Link = System.ComponentModel.DescriptionAttribute;
 
 namespace System.Runtime.CompilerServices;
 
+// Some codebases define their own Debug class, which can cause clashes and compile errors if we aren't explicit here.
+// See comments in Debug.cs in Consume project for more details.
+using Debug = System.Diagnostics.Debug;
+
 /// <summary>Provides a handler used by the language compiler to process interpolated strings into <see cref="string"/> instances.</summary>
 [InterpolatedStringHandler]
 [ExcludeFromCodeCoverage]

--- a/src/Tests/NullabilitySync.cs
+++ b/src/Tests/NullabilitySync.cs
@@ -50,6 +50,7 @@ public class NullabilitySync
                      using System.Linq;
                      using System.Diagnostics.CodeAnalysis;
 
+
                      """;
 
         var suffix = """
@@ -60,6 +61,7 @@ public class NullabilitySync
 
         infoContext = prefix + infoContext + suffix;
         infoContext = MakeInternal(infoContext);
+        infoContext = AddDebugClassFix(infoContext);
         OverWrite(infoContext, "NullabilityInfoContext.cs");
 
         info = prefix + info + suffix;
@@ -85,6 +87,19 @@ public class NullabilitySync
                     public
                     #endif
                     sealed class
+                    """);
+
+    static string AddDebugClassFix(string source) =>
+        source
+            .Replace(
+                "namespace System.Reflection\r\n{",
+                """
+                    namespace System.Reflection
+                    {
+                        // Some codebases define their own Debug class, which can cause clashes and compile errors if we aren't explicit here.
+                        // See comments in Debug.cs in Consume project for more details.
+                        using Debug = System.Diagnostics.Debug;
+                    
                     """);
 
     static void OverWrite(string content, string file)


### PR DESCRIPTION
Extracted from PR #103.

In a project that defined its own `Debug` class, I saw the following errors:

```
/Users/scott/.nuget/packages/polyfill/1.32.0/contentFiles/cs/netstandard2.0/Polyfill/Nullability/NullabilityInfoContext.cs(507,13): error CS0104: 'Debug' is an ambiguous reference between 'MBT.Utilities.Debug' and 'System.Diagnostics.Debug'
/Users/scott/.nuget/packages/polyfill/1.32.0/contentFiles/cs/netstandard2.0/Polyfill/Nullability/NullabilityInfoContext.cs(541,13): error CS0104: 'Debug' is an ambiguous reference between 'MBT.Utilities.Debug' and 'System.Diagnostics.Debug'
```

This PR solves this issue by adding some explicit `using Debug = System.Diagnostics.Debug;` lines in Polyfill.