### PR TITLE
fix: Added missing `ExcludeFromCodeCoverageAttribute`

### DIFF
--- a/src/Polyfill/EnumPolyfill.cs
+++ b/src/Polyfill/EnumPolyfill.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Link = System.ComponentModel.DescriptionAttribute;
 
+[ExcludeFromCodeCoverage]
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/StringInterpolation/AppendInterpolatedStringHandler.cs
+++ b/src/Polyfill/StringInterpolation/AppendInterpolatedStringHandler.cs
@@ -8,6 +8,7 @@ namespace System.Text;
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 /// <summary>Provides a handler used by the language compiler to append interpolated strings into <see cref="StringBuilder"/> instances.</summary>

--- a/src/Polyfill/StringInterpolation/AppendInterpolatedStringHandler.cs
+++ b/src/Polyfill/StringInterpolation/AppendInterpolatedStringHandler.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 /// <summary>Provides a handler used by the language compiler to append interpolated strings into <see cref="StringBuilder"/> instances.</summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 [InterpolatedStringHandler]
+[ExcludeFromCodeCoverage]
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/StringInterpolation/DefaultInterpolatedStringHandler.cs
+++ b/src/Polyfill/StringInterpolation/DefaultInterpolatedStringHandler.cs
@@ -779,6 +779,7 @@ ref struct DefaultInterpolatedStringHandler
     }
 }
 
+[ExcludeFromCodeCoverage]
 static file class InternalMath
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -806,6 +807,7 @@ static file class InternalMath
         throw new ArgumentException(string.Format(SR.Argument_MinMaxValue, min, max));
 }
 
+[ExcludeFromCodeCoverage]
 static file class SR
 {
     public const string Argument_MinMaxValue = "'{0}' cannot be greater than {1}.";


### PR DESCRIPTION
The missing `ExcludeFromCodeCoverageAttribute` has been added to the following classes.

- `EnumPolyfill`
- `AppendInterpolatedStringHandler`
- `InternalMath`
- `SR`