### PR TITLE
Fix SpanLineEnumerator compilation error on .NET 4.6.1 if FeatureMemory is on and FeatureValueTuple is off

### DIFF
--- a/src/Polyfill/SpanLineEnumerator.cs
+++ b/src/Polyfill/SpanLineEnumerator.cs
@@ -78,8 +78,8 @@ ref struct SpanLineEnumerator
                 stride = 2;
             }
 
-            Current = remaining[..index];
-            remaining = remaining[(index + stride)..];
+            Current = remaining.Slice(0, index);
+            remaining = remaining.Slice(index + stride);
             return true;
         }
 


### PR DESCRIPTION
If there is a reference to `System.Memory` but not to `System.ValueTuple` then `SpanLineEnumerator` fails to compile, because it depends on `Range` here:

https://github.com/SimonCropp/Polyfill/blob/74cdf2c5da84ad237e49db4dd1e07f7e14001b02/src/Polyfill/SpanLineEnumerator.cs#L81-L82