### PR TITLE
Add a Dictionary{TKey,}.TryAdd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -512,6 +512,7 @@ The class `Polyfill` includes the following extension methods:
 
 #### Dictionary<TKey,TValue>
 
+ * `Boolean TryAdd<TKey, TValue>(TKey, TValue)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.tryadd)
  * `Boolean Remove<TKey, TValue>(TKey, TValue&)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.remove)
 
 

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -122,6 +122,8 @@ class Consume
         dictionary.GetValueOrDefault("key");
         dictionary.GetValueOrDefault("key", "default");
 
+        dictionary.TryAdd("key", "value");
+
         var concurrentDictionary = new ConcurrentDictionary<string, int>();
 
         var value = concurrentDictionary.GetOrAdd("Hello", (_, arg) => arg.Length, "World");

--- a/src/Polyfill/Polyfill_Dictionary.cs
+++ b/src/Polyfill/Polyfill_Dictionary.cs
@@ -23,7 +23,37 @@ static partial class Polyfill
     public static ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> target) =>
         new(target);
 #endif
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+
+    /// <summary>
+    /// Attempts to add the specified key and value to the dictionary.
+    /// </summary>
+    /// <param name="key">The key of the element to add.</param>
+    /// <param name="value">The value of the element to add. It can be <see langword="null"/>.</param>
+    /// <returns><c>true</c> if the key/value pair was added to the dictionary successfully; otherwise, <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.tryadd")]
+    public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> target, TKey key, TValue value)
+    {
+        if (key is null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (!target.ContainsKey(key))
+        {
+            target.Add(key, value);
+            return true;
+        }
+
+        return false;
+    }
+
+#endif
+
 #if NETFRAMEWORK || NETSTANDARD2_0 || NETCOREAPP2X
+
     /// <summary>
     /// Removes the value with the specified key from the <see cref="Dictionary{TKey,TValue}"/>, and copies the element
     /// to the value parameter.
@@ -44,5 +74,6 @@ static partial class Polyfill
         target.TryGetValue(key, out value);
         return target.Remove(key);
     }
+
 #endif
 }

--- a/src/Tests/PolyfillTests_Dictionary.cs
+++ b/src/Tests/PolyfillTests_Dictionary.cs
@@ -3,7 +3,7 @@ partial class PolyfillTests
     [Test]
     public void IReadOnlyDictionaryAsReadOnly()
     {
-        IDictionary<string, string> dictionary = new Dictionary<string,string>
+        IDictionary<string, string> dictionary = new Dictionary<string, string>
         {
             {"key", "value"}
         };
@@ -13,9 +13,39 @@ partial class PolyfillTests
     }
 
     [Test]
+    public void Dictionary_TryAdd_ThrowsOnNullKey()
+    {
+        var dictionary = new Dictionary<string, int>();
+
+        Assert.Throws<ArgumentNullException>(() => dictionary.TryAdd(null!, 1));
+    }
+
+    [Test]
+    public void Dictionary_TryAdd_ReturnsTrueOnSuccessfulAdd()
+    {
+        var dictionary = new Dictionary<string, string>();
+
+        var entryAdded = dictionary.TryAdd("key", "value");
+
+        Assert.True(entryAdded);
+        Assert.AreEqual("value", dictionary["key"]);
+    }
+
+    [Test]
+    public void Dictionary_TryAdd_ReturnsFalseIfElementAlreadyPresent()
+    {
+        var dictionary = new Dictionary<string, string>() { { "existingKey", "original value" } };
+
+        var entryAdded = dictionary.TryAdd("existingKey", "new value");
+
+        Assert.False(entryAdded);
+        Assert.AreEqual("original value", dictionary["existingKey"]);
+    }
+
+    [Test]
     public void Dictionary_Remove()
     {
-        var dictionary = new Dictionary<string, string?> { {"key", "value"} };
+        var dictionary = new Dictionary<string, string?> { { "key", "value" } };
 
         Assert.True(dictionary.Remove("key", out var value));
         Assert.AreEqual("value", value);


### PR DESCRIPTION
Add a Dictionary{TKey, TValue} method to the polyfill.

Thanks for the library, it helped me a lot.

BTW, you might want to expand documenation in [contributing.md](https://github.com/SimonCropp/Polyfill/blob/main/contributing.md#add-to-the-consume-project) about how to add (how usage should look like) usage of API to `Consume` project. There is a main chunk of code in the ctor and then there are many unreferenced methods (generally in form {ClassName}{MethodName}). I have just added a method next to other ones for Dictionary in ctor, but it might be good to define pattern how it should be implemented. 