### PR TITLE
New convention for Consume project

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -409,4 +409,8 @@ Add documentation for the API to the `readme.md`.
 
 ### Add to the Consume project
 
-Add a simple usage of the API to the Consume project.
+Add a simple usage of the API to the Consume project. The usage is there to check it compiles on old runtimes, not correctness.
+
+Put a usage of polyfilled class method into a method in `Consume.cs` with suffix `_Methods` (e.g. `Stream_Methods` for `Stream` type methods). Keep method names in alphabetical order, do not use modifiers.
+
+If new API is a compiler API (e.g. that polyfilled deconstruct method can be used in foreach loop), put usage into *Compiler Features* region.

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -76,147 +76,9 @@ class Consume
         type = typeof(RequiresUnreferencedCodeAttribute);
         type = typeof(UnreachableException);
 
-#if FeatureValueTuple
-        var range = "value"[1..];
-        var index = "value"[^2];
-        //Array not supported due to no RuntimeHelpers.GetSubArray
-        // var subArray = new[]
-        // {
-        //     "value1",
-        //     "value2"
-        // }[..1];
-#endif
-
-        var startsWith = "value".StartsWith('a');
-        var endsWith = "value".EndsWith('a');
-
-        IList<string> ilist = new List<string>();
-        ilist.AsReadOnly();
-
-        IDictionary<int, int> idictionary = new Dictionary<int, int>();
-        idictionary.AsReadOnly();
-
-        typeof(List<string>).IsAssignableTo(typeof(string));
-        typeof(List<string>).IsAssignableTo(null);
-
-        var enumerable = (IEnumerable<string>)new List<string>
-        {
-            "a",
-            "b"
-        };
-        enumerable.TryGetNonEnumeratedCount(out var count);
-        var append = enumerable.Append("c");
-        var maxBy = enumerable.MaxBy(_ => _);
-        var chunk = enumerable.Chunk(3);
-        var minBy = enumerable.MinBy(_ => _);
-        var distinctBy = enumerable.DistinctBy(_ => _);
-        var skipLast = enumerable.SkipLast(1);
-
-        var dictionary = new Dictionary<string, string?>
-        {
-            {
-                "key", "value"
-            }
-        };
-
-        dictionary.GetValueOrDefault("key");
-        dictionary.GetValueOrDefault("key", "default");
-
-        dictionary.TryAdd("key", "value");
-
-        var concurrentDictionary = new ConcurrentDictionary<string, int>();
-
-        var value = concurrentDictionary.GetOrAdd("Hello", (_, arg) => arg.Length, "World");
-
-        var split = "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        split = "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
-        var contains = "a b".Contains(' ');
-
         // Test to make sure there are no clashes in the Polyfill code with classes that
         // might be defined in user code. See comments in Debug.cs for more details.
         Debug.Log("Test log to make sure this is working");
-
-        BytePolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        BytePolyfill.TryParse("1"u8, null, out _);
-        BytePolyfill.TryParse(['1'], out _);
-        BytePolyfill.TryParse(['1'], null, out _);
-        BytePolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        BytePolyfill.TryParse("1"u8, out _);
-        BytePolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        DoublePolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        DoublePolyfill.TryParse("1"u8, null, out _);
-        DoublePolyfill.TryParse(['1'], out _);
-        DoublePolyfill.TryParse(['1'], null, out _);
-        DoublePolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        DoublePolyfill.TryParse("1"u8, out _);
-        DoublePolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        IntPolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        IntPolyfill.TryParse("1"u8, null, out _);
-        IntPolyfill.TryParse(['1'], out _);
-        IntPolyfill.TryParse(['1'], null, out _);
-        IntPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        IntPolyfill.TryParse("1"u8, out _);
-        IntPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        LongPolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        LongPolyfill.TryParse("1"u8, null, out _);
-        LongPolyfill.TryParse(['1'], out _);
-        LongPolyfill.TryParse(['1'], null, out _);
-        LongPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        LongPolyfill.TryParse("1"u8, out _);
-        LongPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        SBytePolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        SBytePolyfill.TryParse("1"u8, null, out _);
-        SBytePolyfill.TryParse(['1'], out _);
-        SBytePolyfill.TryParse(['1'], null, out _);
-        SBytePolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        SBytePolyfill.TryParse("1"u8, out _);
-        SBytePolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        ShortPolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        ShortPolyfill.TryParse("1"u8, null, out _);
-        ShortPolyfill.TryParse(['1'], out _);
-        ShortPolyfill.TryParse(['1'], null, out _);
-        ShortPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        ShortPolyfill.TryParse("1"u8, out _);
-        ShortPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        UIntPolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        UIntPolyfill.TryParse("1"u8, null, out _);
-        UIntPolyfill.TryParse(['1'], out _);
-        UIntPolyfill.TryParse(['1'], null, out _);
-        UIntPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        UIntPolyfill.TryParse("1"u8, out _);
-        UIntPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        ULongPolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        ULongPolyfill.TryParse("1"u8, null, out _);
-        ULongPolyfill.TryParse(['1'], out _);
-        ULongPolyfill.TryParse(['1'], null, out _);
-        ULongPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        ULongPolyfill.TryParse("1"u8, out _);
-        ULongPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
-        UShortPolyfill.TryParse("1", null, out _);
-#if FeatureMemory
-        UShortPolyfill.TryParse("1"u8, null, out _);
-        UShortPolyfill.TryParse(['1'], out _);
-        UShortPolyfill.TryParse(['1'], null, out _);
-        UShortPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
-        UShortPolyfill.TryParse("1"u8, out _);
-        UShortPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
-#endif
     }
 
     #region Compiler Features
@@ -280,7 +142,34 @@ class Consume
     }
 #endif
 
+#if FeatureValueTuple
+    void Ranges()
+    {
+        var range = "value"[1..];
+        var index = "value"[^2];
+        //Array not supported due to no RuntimeHelpers.GetSubArray
+        // var subArray = new[]
+        // {
+        //     "value1",
+        //     "value2"
+        // }[..1];
+    }
+#endif
+
     #endregion
+
+    void Byte_Methods()
+    {
+        BytePolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        BytePolyfill.TryParse("1"u8, null, out _);
+        BytePolyfill.TryParse(['1'], out _);
+        BytePolyfill.TryParse(['1'], null, out _);
+        BytePolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        BytePolyfill.TryParse("1"u8, out _);
+        BytePolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
 
     void CancellationToken_Methods()
     {
@@ -294,6 +183,33 @@ class Consume
     {
         var source = new CancellationTokenSource();
         await source.CancelAsync();
+    }
+
+    void ConcurrentDictionary()
+    {
+        var dict = new ConcurrentDictionary<string, int>();
+        var value = dict.GetOrAdd("Hello", (_, arg) => arg.Length, "World");
+    }
+
+    void Dictionary_Methods()
+    {
+        var dictionary = new Dictionary<string, string?> { { "key", "value" } };
+        dictionary.GetValueOrDefault("key");
+        dictionary.GetValueOrDefault("key", "default");
+        dictionary.TryAdd("key", "value");
+    }
+
+    void Double_Methods()
+    {
+        DoublePolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        DoublePolyfill.TryParse("1"u8, null, out _);
+        DoublePolyfill.TryParse(['1'], out _);
+        DoublePolyfill.TryParse(['1'], null, out _);
+        DoublePolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        DoublePolyfill.TryParse("1"u8, out _);
+        DoublePolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
     }
 
     void HashSet_Methods()
@@ -321,6 +237,47 @@ class Consume
     }
 #endif
 
+    void IDictionary_Methods()
+    {
+        IDictionary<int, int> idictionary = new Dictionary<int, int>();
+        idictionary.AsReadOnly();
+    }
+
+    void IEnumerable_Methods()
+    {
+        var enumerable = (IEnumerable<string>)new List<string>
+        {
+            "a",
+            "b"
+        };
+        enumerable.TryGetNonEnumeratedCount(out var count);
+        var append = enumerable.Append("c");
+        var maxBy = enumerable.MaxBy(_ => _);
+        var chunk = enumerable.Chunk(3);
+        var minBy = enumerable.MinBy(_ => _);
+        var distinctBy = enumerable.DistinctBy(_ => _);
+        var skipLast = enumerable.SkipLast(1);
+    }
+
+    void IList_Methods()
+    {
+        IList<string> ilist = new List<string>();
+        ilist.AsReadOnly();
+    }
+
+    void Int_Methods()
+    {
+        IntPolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        IntPolyfill.TryParse("1"u8, null, out _);
+        IntPolyfill.TryParse(['1'], out _);
+        IntPolyfill.TryParse(['1'], null, out _);
+        IntPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        IntPolyfill.TryParse("1"u8, out _);
+        IntPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
+
 #if FeatureMemory
     void List_Methods()
     {
@@ -331,6 +288,19 @@ class Consume
         list.InsertRange(1, "bc".AsSpan());
     }
 #endif
+
+    void Long_Methods()
+    {
+        LongPolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        LongPolyfill.TryParse("1"u8, null, out _);
+        LongPolyfill.TryParse(['1'], out _);
+        LongPolyfill.TryParse(['1'], null, out _);
+        LongPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        LongPolyfill.TryParse("1"u8, out _);
+        LongPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
 
     void MemberInfoMethods(MemberInfo info)
     {
@@ -381,6 +351,32 @@ class Consume
     }
 #endif
 
+    void SByte_Methods()
+    {
+        SBytePolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        SBytePolyfill.TryParse("1"u8, null, out _);
+        SBytePolyfill.TryParse(['1'], out _);
+        SBytePolyfill.TryParse(['1'], null, out _);
+        SBytePolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        SBytePolyfill.TryParse("1"u8, out _);
+        SBytePolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
+
+    void Short_Methods()
+    {
+        ShortPolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        ShortPolyfill.TryParse("1"u8, null, out _);
+        ShortPolyfill.TryParse(['1'], out _);
+        ShortPolyfill.TryParse(['1'], null, out _);
+        ShortPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        ShortPolyfill.TryParse("1"u8, out _);
+        ShortPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
+
     void SortedList_Methods()
     {
         var list = new SortedList<int, char>();
@@ -413,6 +409,15 @@ class Consume
         var count = await reader.ReadAsync(memory);
         var line = await reader.ReadLineAsync(CancellationToken.None);
         var text = await reader.ReadToEndAsync(CancellationToken.None);
+    }
+
+    void String_Methods()
+    {
+        var contains = "a b".Contains(' ');
+        var endsWith = "value".EndsWith('a');
+        var split = "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        split = "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+        var startsWith = "value".StartsWith('a');
     }
 
     void StringBuilder_Methods()
@@ -470,8 +475,50 @@ class Consume
 #endif
     void Type_Methods(MemberInfo info)
     {
+        bool result;
+        result = typeof(List<string>).IsAssignableTo(typeof(string));
+        result = typeof(List<string>).IsAssignableTo(null);
+        result = typeof(string).IsGenericMethodParameter();
         var member = typeof(string).GetMemberWithSameMetadataDefinitionAs(info);
-        var result = typeof(string).IsGenericMethodParameter();
+    }
+
+    void UInt_Methods()
+    {
+        UIntPolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        UIntPolyfill.TryParse("1"u8, null, out _);
+        UIntPolyfill.TryParse(['1'], out _);
+        UIntPolyfill.TryParse(['1'], null, out _);
+        UIntPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        UIntPolyfill.TryParse("1"u8, out _);
+        UIntPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
+
+    void ULong_Methods()
+    {
+        ULongPolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        ULongPolyfill.TryParse("1"u8, null, out _);
+        ULongPolyfill.TryParse(['1'], out _);
+        ULongPolyfill.TryParse(['1'], null, out _);
+        ULongPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        ULongPolyfill.TryParse("1"u8, out _);
+        ULongPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
+    }
+
+    void UShort_Methods()
+    {
+        UShortPolyfill.TryParse("1", null, out _);
+#if FeatureMemory
+        UShortPolyfill.TryParse("1"u8, null, out _);
+        UShortPolyfill.TryParse(['1'], out _);
+        UShortPolyfill.TryParse(['1'], null, out _);
+        UShortPolyfill.TryParse("1"u8, NumberStyles.Integer, null, out _);
+        UShortPolyfill.TryParse("1"u8, out _);
+        UShortPolyfill.TryParse(['1'], NumberStyles.Integer, null, out _);
+#endif
     }
 
     void XDocument_Methods()

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -99,7 +99,7 @@ class Consume
         typeof(List<string>).IsAssignableTo(typeof(string));
         typeof(List<string>).IsAssignableTo(null);
 
-        var enumerable = (IEnumerable<string>) new List<string>
+        var enumerable = (IEnumerable<string>)new List<string>
         {
             "a",
             "b"
@@ -219,25 +219,8 @@ class Consume
 #endif
     }
 
-#if FetureHttp
-
-    static void Http()
-    {
-        new HttpClient().GetStreamAsync("", CancellationToken.None);
-        new HttpClient().GetStreamAsync(new Uri(""), CancellationToken.None);
-        new HttpClient().GetByteArrayAsync("", CancellationToken.None);
-        new HttpClient().GetByteArrayAsync(new Uri(""), CancellationToken.None);
-        new HttpClient().GetStringAsync("", CancellationToken.None);
-        new HttpClient().GetStringAsync(new Uri(""), CancellationToken.None);
-
-        new ByteArrayContent([]).ReadAsStreamAsync(CancellationToken.None);
-        new ByteArrayContent([]).ReadAsByteArrayAsync(CancellationToken.None);
-        new ByteArrayContent([]).ReadAsStringAsync(CancellationToken.None);
-    }
-
-#endif
-
-    void KeyValuePairDeconstruct(IEnumerable<KeyValuePair<string, string>> variables)
+    #region Compiler Features
+    void DeconstructTupleInForeach(IEnumerable<KeyValuePair<string, string>> variables)
     {
         foreach (var (name, value) in variables)
         {
@@ -259,14 +242,47 @@ class Consume
     static void ExperimentalMethod()
     {
     }
+#pragma warning restore ExperimentalMethod
 
-    async Task CancellationTokenSource()
+    [RequiresPreviewFeatures("This method uses a preview feature.")]
+    void UsePreviewFeature()
     {
-        var source = new CancellationTokenSource();
-        await source.CancelAsync();
     }
 
-    void CancellationTokenUnsafeRegister()
+    [OverloadResolutionPriority(1)]
+    void Method(int x)
+    {
+    }
+
+    [OverloadResolutionPriority(2)]
+    void Method(string x)
+    {
+    }
+
+    [OverloadResolutionPriority(3)]
+    void Method(object x)
+    {
+    }
+
+#if FeatureMemory
+    void CollectionBuilderAttribute()
+    {
+        MyCollection myCollection = [1, 2, 3, 4, 5];
+    }
+
+    [CollectionBuilder(typeof(MyCollection), nameof(Create))]
+    class MyCollection(ReadOnlySpan<int> initValues)
+    {
+        readonly int[] values = initValues.ToArray();
+        public IEnumerator<int> GetEnumerator() => ((IEnumerable<int>)values).GetEnumerator();
+
+        public static MyCollection Create(ReadOnlySpan<int> values) => new(values);
+    }
+#endif
+
+    #endregion
+
+    void CancellationToken_UnsafeRegister()
     {
         var source = new CancellationTokenSource();
         var token = source.Token;
@@ -278,32 +294,224 @@ class Consume
         }, null);
     }
 
-    void TaskCompletionSource_SetCanceled_WithCancellationToken()
+    async Task CancellationTokenSource_CancelAsync()
     {
-        var completionSource = new TaskCompletionSource<int>();
-        var tokenSource = new CancellationTokenSource();
-        completionSource.SetCanceled(tokenSource.Token);
+        var source = new CancellationTokenSource();
+        await source.CancelAsync();
     }
 
-    async Task ProcessWaitForExitAsync()
+    void HashSet_TryGetValue()
+    {
+        var set = new HashSet<string>
+        {
+            "value"
+        };
+        var found = set.TryGetValue("value", out var result);
+    }
+
+#if FetureHttp
+    static void HttpClient()
+    {
+        new HttpClient().GetStreamAsync("", CancellationToken.None);
+        new HttpClient().GetStreamAsync(new Uri(""), CancellationToken.None);
+        new HttpClient().GetByteArrayAsync("", CancellationToken.None);
+        new HttpClient().GetByteArrayAsync(new Uri(""), CancellationToken.None);
+        new HttpClient().GetStringAsync("", CancellationToken.None);
+        new HttpClient().GetStringAsync(new Uri(""), CancellationToken.None);
+    }
+
+    static void HttpContent()
+    {
+        new ByteArrayContent([]).ReadAsStreamAsync(CancellationToken.None);
+        new ByteArrayContent([]).ReadAsByteArrayAsync(CancellationToken.None);
+        new ByteArrayContent([]).ReadAsStringAsync(CancellationToken.None);
+    }
+#endif
+
+#if FeatureMemory
+    void List_AddRange_ReadOnlySpan()
+    {
+        var list = new List<char>();
+        list.AddRange("ab".AsSpan());
+    }
+#endif
+
+#if FeatureMemory
+    void List_CopyToSpan()
+    {
+        var list = new List<char>
+        {
+            'a'
+        };
+        var array = new char[1];
+        list.CopyTo(array.AsSpan());
+    }
+#endif
+
+#if FeatureMemory
+    void List_InsertRange_ReadOnlySpan()
+    {
+        var list = new List<char>
+        {
+            'a'
+        };
+        list.InsertRange(1, "bc".AsSpan());
+    }
+#endif
+
+    void MemberInfo_HasSameMetadataDefinitionAs(MemberInfo info)
+    {
+        var result = info.HasSameMetadataDefinitionAs(info);
+    }
+
+    async Task Process_WaitForExitAsync()
     {
         var process = new Process();
         await process.WaitForExitAsync();
     }
 
-    async Task StreamReaderReadToEndAsync()
+#if FeatureMemory
+    void Random_NextBytes_Span()
     {
-        var reader = new StreamReader(new MemoryStream());
-        var read = await reader.ReadToEndAsync(CancellationToken.None);
+        var random = new Random();
+        Span<byte> buffer = new byte[10];
+        random.NextBytes(buffer);
+    }
+#endif
+
+    void Random_Shuffle_Array()
+    {
+        var random = new Random();
+        var buffer = new byte[10];
+        random.Shuffle(buffer);
     }
 
-    async Task StreamReaderReadLineAsync()
+#if FeatureMemory
+    void Random_Shuffle_Span()
+    {
+        var random = new Random();
+        Span<byte> span = new byte[10];
+        random.Shuffle(span);
+    }
+#endif
+
+#if FeatureMemory
+    void ReadOnlySpan_EnumerateLines()
+    {
+        foreach (var line in "ab".AsSpan().EnumerateLines())
+        {
+        }
+    }
+#endif
+
+#if FeatureMemory
+    void Regex_IsMatch()
+    {
+        var regex = new Regex("result");
+        regex.IsMatch("value".AsSpan());
+    }
+#endif
+
+    void SortedList()
+    {
+        var list = new SortedList<int, char>();
+        var key = list.GetKeyAtIndex(0);
+        var value = list.GetValueAtIndex(0);
+    }
+
+#if FeatureMemory
+    void Span_EndsWith()
+    {
+        var result = "value".AsSpan().EndsWith("value");
+        result = "value".AsSpan().EndsWith("value", StringComparison.Ordinal);
+    }
+
+    void Span_SequenceEqual()
+    {
+        var result = "value".AsSpan().SequenceEqual("value");
+    }
+    void Span_StartsWith()
+    {
+        var startsWith = "value".AsSpan().StartsWith("value");
+        startsWith = "value".AsSpan().StartsWith("value", StringComparison.Ordinal);
+    }
+
+    void Span_TrimEnd()
+    {
+        var span = new Span<char>(new char[1]);
+        span.TrimEnd();
+    }
+
+    void Span_TrimStart()
+    {
+        var span = new Span<char>(new char[1]);
+        span.TrimStart();
+    }
+
+    async Task Stream_ReadAsync()
+    {
+        var input = new byte[]
+        {
+            1,
+            2
+        };
+        using var stream = new MemoryStream(input);
+        var result = new byte[2];
+        var memory = new Memory<byte>(result);
+        var read = await stream.ReadAsync(memory);
+    }
+
+    async Task StreamReader_ReadAsync()
+    {
+        var result = new char[5];
+        var memory = new Memory<char>(result);
+        var reader = new StreamReader(new MemoryStream());
+        var read = await reader.ReadAsync(memory);
+    }
+
+    async Task StreamReader_ReadLineAsync()
     {
         TextReader reader = new StreamReader(new MemoryStream());
         var read = await reader.ReadLineAsync(CancellationToken.None);
     }
 
-    void WaitAsync()
+    async Task StreamReader_ReadToEndAsync()
+    {
+        var reader = new StreamReader(new MemoryStream());
+        var read = await reader.ReadToEndAsync(CancellationToken.None);
+    }
+
+    void StringBuilder_Append_Span()
+    {
+        var builder = new StringBuilder();
+        builder.Append("value".AsSpan());
+    }
+
+    void StringBuilder_CopyTo()
+    {
+        var builder = new StringBuilder("value");
+        var span = new Span<char>(new char[1]);
+        builder.CopyTo(0, span, 1);
+    }
+
+    void StringBuilder_Equals_Span()
+    {
+        var builder = new StringBuilder("value");
+        var equals = builder.Equals("value".AsSpan());
+    }
+#endif
+
+#if NET6_0_OR_GREATER
+    void StringBuilder_Replace_ReadOnlySpan()
+    {
+        var builder = new StringBuilder();
+
+        var result = builder.Replace("a".AsSpan(), "a".AsSpan());
+        result = builder.Replace("a".AsSpan(), "a".AsSpan(), 1, 1);
+    }
+#endif
+
+    void Task_WaitAsync()
     {
         var action = () =>
         {
@@ -317,170 +525,16 @@ class Consume
         new Task<int>(func).WaitAsync(TimeSpan.Zero, CancellationToken.None);
     }
 
-#if FeatureMemory
-
-    public void ListAddRangeReadOnlySpan()
-    {
-        var list = new List<char>();
-        list.AddRange("ab".AsSpan());
-    }
-
-    public void EnumerateLinesReadOnlySpan()
-    {
-        foreach (var line in "ab".AsSpan().EnumerateLines())
-        {
-        }
-    }
-
-    public void ListInsertRangeReadOnlySpan()
-    {
-        var list = new List<char>
-        {
-            'a'
-        };
-        list.InsertRange(1, "bc".AsSpan());
-    }
-
-    public void ListCopyToSpan()
-    {
-        var list = new List<char>
-        {
-            'a'
-        };
-        var array = new char[1];
-        list.CopyTo(array.AsSpan());
-    }
-
-    async Task StreamReaderReadAsync()
-    {
-        var result = new char[5];
-        var memory = new Memory<char>(result);
-        var reader = new StreamReader(new MemoryStream());
-        var read = await reader.ReadAsync(memory);
-    }
-
-    void RegexIsMatch()
-    {
-        var regex = new Regex("result");
-        regex.IsMatch("value".AsSpan());
-    }
-
-    async Task StreamReadAsync()
-    {
-        var input = new byte[]
-        {
-            1,
-            2
-        };
-        using var stream = new MemoryStream(input);
-        var result = new byte[2];
-        var memory = new Memory<byte>(result);
-        var read = await stream.ReadAsync(memory);
-    }
-
-    void StringBuilderCopyTo()
-    {
-        var builder = new StringBuilder("value");
-        var span = new Span<char>(new char[1]);
-        builder.CopyTo(0, span, 1);
-    }
-
-    void SpanTrimEnd()
-    {
-        var span = new Span<char>(new char[1]);
-        span.TrimEnd();
-        span.TrimStart();
-    }
-
-    void SpanSequenceEqual()
-    {
-        var result = "value".AsSpan().SequenceEqual("value");
-    }
-
-    void SpanStartsWith()
-    {
-        var startsWith = "value".AsSpan().StartsWith("value");
-        startsWith = "value".AsSpan().StartsWith("value", StringComparison.Ordinal);
-    }
-
-    void SpanEndsWith()
-    {
-        var result = "value".AsSpan().EndsWith("value");
-        result = "value".AsSpan().EndsWith("value", StringComparison.Ordinal);
-    }
-
-    void SpanStringBuilderAppend()
-    {
-        var builder = new StringBuilder();
-        builder.Append("value".AsSpan());
-    }
-
-    void StringEqualsSpan()
-    {
-        var builder = new StringBuilder("value");
-        var equals = builder.Equals("value".AsSpan());
-    }
-
-    public void CollectionBuilderAttribute()
-    {
-        MyCollection myCollection = [1, 2, 3, 4, 5];
-    }
-
-    [CollectionBuilder(typeof(MyCollection), nameof(Create))]
-    public class MyCollection(ReadOnlySpan<int> initValues)
-    {
-        readonly int[] values = initValues.ToArray();
-        public IEnumerator<int> GetEnumerator() => ((IEnumerable<int>) values).GetEnumerator();
-
-        public static MyCollection Create(ReadOnlySpan<int> values) => new(values);
-    }
-
-#endif
-
-    void IsGenericMethodParameter()
-    {
-        var result = typeof(string).IsGenericMethodParameter();
-    }
-
-    void HashSetTryGetValue()
-    {
-        var set = new HashSet<string>
-        {
-            "value"
-        };
-        var found = set.TryGetValue("value", out var result);
-    }
-#if NET6_0_OR_GREATER
-    void StringBuilderReplaceReadOnlySpan()
-    {
-        var builder = new StringBuilder();
-
-        var result = builder.Replace("a".AsSpan(), "a".AsSpan());
-        result = builder.Replace("a".AsSpan(), "a".AsSpan(), 1, 1);
-    }
-#endif
-
-    void HasSameMetadataDefinitionAs(MemberInfo info)
-    {
-        var result = info.HasSameMetadataDefinitionAs(info);
-    }
-
-    void GetMemberWithSameMetadataDefinitionAs(MemberInfo info)
-    {
-        var result = typeof(string).GetMemberWithSameMetadataDefinitionAs(info);
-    }
-
-    void XDocumentSaveAsync()
-    {
-        var document = new XDocument();
-        document.SaveAsync(new XmlTextWriter(null!), CancellationToken.None);
-        document.SaveAsync(new StringWriter(), SaveOptions.None, CancellationToken.None);
-        document.SaveAsync(new MemoryStream(), SaveOptions.None, CancellationToken.None);
-    }
-
-    void NonGenericTaskCompletionSource()
+    void TaskCompletionSource_NonGeneric()
     {
         var tcs = new TaskCompletionSource();
+    }
+
+    void TaskCompletionSource_SetCanceled_WithCancellationToken()
+    {
+        var completionSource = new TaskCompletionSource<int>();
+        var tokenSource = new CancellationTokenSource();
+        completionSource.SetCanceled(tokenSource.Token);
     }
 
 #if FeatureMemory
@@ -494,53 +548,22 @@ class Consume
         target.Write("a".AsSpan());
         await target.WriteAsync("a".AsMemory());
     }
-
-    void RandomNextBytesSpan()
-    {
-        var random = new Random();
-        Span<byte> buffer = new byte[10];
-        random.NextBytes(buffer);
-    }
-
-    void RandomShuffleSpan()
-    {
-        var random = new Random();
-        Span<byte> span = new byte[10];
-        random.Shuffle(span);
-    }
 #endif
-
-    void RandomShuffle()
+    void Type_GetMemberWithSameMetadataDefinitionAs(MemberInfo info)
     {
-        var random = new Random();
-        var buffer = new byte[10];
-        random.Shuffle(buffer);
+        var result = typeof(string).GetMemberWithSameMetadataDefinitionAs(info);
     }
 
-    public void SortedList()
+    void Type_IsGenericMethodParameter()
     {
-        var list = new SortedList<int, char>();
-        var key = list.GetKeyAtIndex(0);
-        var value = list.GetValueAtIndex(0);
+        var result = typeof(string).IsGenericMethodParameter();
     }
 
-    [OverloadResolutionPriority(1)]
-    public void Method(int x)
+    void XDocument_SaveAsync()
     {
-    }
-
-    [OverloadResolutionPriority(2)]
-    public void Method(string x)
-    {
-    }
-
-    [OverloadResolutionPriority(3)]
-    public void Method(object x)
-    {
-    }
-
-    [RequiresPreviewFeatures("This method uses a preview feature.")]
-    public void UsePreviewFeature()
-    {
+        var document = new XDocument();
+        document.SaveAsync(new XmlTextWriter(null!), CancellationToken.None);
+        document.SaveAsync(new StringWriter(), SaveOptions.None, CancellationToken.None);
+        document.SaveAsync(new MemoryStream(), SaveOptions.None, CancellationToken.None);
     }
 }

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -179,13 +179,13 @@ class Consume
         token.UnsafeRegister((state, token) => { }, null);
     }
 
-    async Task CancellationTokenSource()
+    async Task CancellationTokenSource_Methods()
     {
         var source = new CancellationTokenSource();
         await source.CancelAsync();
     }
 
-    void ConcurrentDictionary()
+    void ConcurrentDictionary_Methods()
     {
         var dict = new ConcurrentDictionary<string, int>();
         var value = dict.GetOrAdd("Hello", (_, arg) => arg.Length, "World");
@@ -302,7 +302,7 @@ class Consume
 #endif
     }
 
-    void MemberInfoMethods(MemberInfo info)
+    void MemberInfo_Methods(MemberInfo info)
     {
         var result = info.HasSameMetadataDefinitionAs(info);
     }

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -282,35 +282,28 @@ class Consume
 
     #endregion
 
-    void CancellationToken_UnsafeRegister()
+    void CancellationToken_Methods()
     {
         var source = new CancellationTokenSource();
         var token = source.Token;
-        token.UnsafeRegister(state =>
-        {
-        }, null);
-        token.UnsafeRegister((state, token) =>
-        {
-        }, null);
+        token.UnsafeRegister(state => { }, null);
+        token.UnsafeRegister((state, token) => { }, null);
     }
 
-    async Task CancellationTokenSource_CancelAsync()
+    async Task CancellationTokenSource()
     {
         var source = new CancellationTokenSource();
         await source.CancelAsync();
     }
 
-    void HashSet_TryGetValue()
+    void HashSet_Methods()
     {
-        var set = new HashSet<string>
-        {
-            "value"
-        };
+        var set = new HashSet<string> { "value" };
         var found = set.TryGetValue("value", out var result);
     }
 
 #if FetureHttp
-    static void HttpClient()
+    void HttpClient_Methods()
     {
         new HttpClient().GetStreamAsync("", CancellationToken.None);
         new HttpClient().GetStreamAsync(new Uri(""), CancellationToken.None);
@@ -320,7 +313,7 @@ class Consume
         new HttpClient().GetStringAsync(new Uri(""), CancellationToken.None);
     }
 
-    static void HttpContent()
+    void HttpContent_Methods()
     {
         new ByteArrayContent([]).ReadAsStreamAsync(CancellationToken.None);
         new ByteArrayContent([]).ReadAsByteArrayAsync(CancellationToken.None);
@@ -329,90 +322,66 @@ class Consume
 #endif
 
 #if FeatureMemory
-    void List_AddRange_ReadOnlySpan()
+    void List_Methods()
     {
         var list = new List<char>();
-        list.AddRange("ab".AsSpan());
-    }
-#endif
-
-#if FeatureMemory
-    void List_CopyToSpan()
-    {
-        var list = new List<char>
-        {
-            'a'
-        };
         var array = new char[1];
+        list.AddRange("ab".AsSpan());
         list.CopyTo(array.AsSpan());
-    }
-#endif
-
-#if FeatureMemory
-    void List_InsertRange_ReadOnlySpan()
-    {
-        var list = new List<char>
-        {
-            'a'
-        };
         list.InsertRange(1, "bc".AsSpan());
     }
 #endif
 
-    void MemberInfo_HasSameMetadataDefinitionAs(MemberInfo info)
+    void MemberInfoMethods(MemberInfo info)
     {
         var result = info.HasSameMetadataDefinitionAs(info);
     }
 
-    async Task Process_WaitForExitAsync()
+    async Task Process_Methods()
     {
         var process = new Process();
         await process.WaitForExitAsync();
     }
 
-#if FeatureMemory
-    void Random_NextBytes_Span()
+    void Random_Methods()
     {
         var random = new Random();
-        Span<byte> buffer = new byte[10];
-        random.NextBytes(buffer);
-    }
+#if FeatureMemory
+        Span<byte> bufferSpan = new byte[10];
+        random.NextBytes(bufferSpan);
+        random.Shuffle(bufferSpan);
 #endif
-
-    void Random_Shuffle_Array()
-    {
-        var random = new Random();
-        var buffer = new byte[10];
-        random.Shuffle(buffer);
+        var bufferArray = new byte[10];
+        random.Shuffle(bufferArray);
     }
 
 #if FeatureMemory
-    void Random_Shuffle_Span()
+    void ReadOnlySpan_Methods()
     {
-        var random = new Random();
-        Span<byte> span = new byte[10];
-        random.Shuffle(span);
-    }
-#endif
-
-#if FeatureMemory
-    void ReadOnlySpan_EnumerateLines()
-    {
-        foreach (var line in "ab".AsSpan().EnumerateLines())
+        var readOnlySpan = "value".AsSpan();
+        foreach (var line in readOnlySpan.EnumerateLines())
         {
         }
+
+        bool result;
+        result = readOnlySpan.EndsWith("value");
+        result = readOnlySpan.EndsWith("value", StringComparison.Ordinal);
+        result = readOnlySpan.SequenceEqual("value");
+        result = readOnlySpan.StartsWith("value");
+        result = readOnlySpan.StartsWith("value", StringComparison.Ordinal);
     }
+
 #endif
 
 #if FeatureMemory
-    void Regex_IsMatch()
+    void Regex_Methods()
     {
         var regex = new Regex("result");
         regex.IsMatch("value".AsSpan());
     }
 #endif
 
-    void SortedList()
+    void SortedList_Methods()
     {
         var list = new SortedList<int, char>();
         var key = list.GetKeyAtIndex(0);
@@ -420,98 +389,48 @@ class Consume
     }
 
 #if FeatureMemory
-    void Span_EndsWith()
-    {
-        var result = "value".AsSpan().EndsWith("value");
-        result = "value".AsSpan().EndsWith("value", StringComparison.Ordinal);
-    }
-
-    void Span_SequenceEqual()
-    {
-        var result = "value".AsSpan().SequenceEqual("value");
-    }
-    void Span_StartsWith()
-    {
-        var startsWith = "value".AsSpan().StartsWith("value");
-        startsWith = "value".AsSpan().StartsWith("value", StringComparison.Ordinal);
-    }
-
-    void Span_TrimEnd()
+    void Span_Methods()
     {
         var span = new Span<char>(new char[1]);
-        span.TrimEnd();
+        _ = span.TrimEnd();
+        _ = span.TrimStart();
     }
 
-    void Span_TrimStart()
+    async Task Stream_Methods()
     {
-        var span = new Span<char>(new char[1]);
-        span.TrimStart();
-    }
-
-    async Task Stream_ReadAsync()
-    {
-        var input = new byte[]
-        {
-            1,
-            2
-        };
+        var input = new byte[] { 1, 2 };
         using var stream = new MemoryStream(input);
         var result = new byte[2];
         var memory = new Memory<byte>(result);
         var read = await stream.ReadAsync(memory);
     }
 
-    async Task StreamReader_ReadAsync()
+    async Task StreamReader_Methods()
     {
         var result = new char[5];
         var memory = new Memory<char>(result);
         var reader = new StreamReader(new MemoryStream());
-        var read = await reader.ReadAsync(memory);
+        var count = await reader.ReadAsync(memory);
+        var line = await reader.ReadLineAsync(CancellationToken.None);
+        var text = await reader.ReadToEndAsync(CancellationToken.None);
     }
 
-    async Task StreamReader_ReadLineAsync()
-    {
-        TextReader reader = new StreamReader(new MemoryStream());
-        var read = await reader.ReadLineAsync(CancellationToken.None);
-    }
-
-    async Task StreamReader_ReadToEndAsync()
-    {
-        var reader = new StreamReader(new MemoryStream());
-        var read = await reader.ReadToEndAsync(CancellationToken.None);
-    }
-
-    void StringBuilder_Append_Span()
-    {
-        var builder = new StringBuilder();
-        builder.Append("value".AsSpan());
-    }
-
-    void StringBuilder_CopyTo()
+    void StringBuilder_Methods()
     {
         var builder = new StringBuilder("value");
-        var span = new Span<char>(new char[1]);
-        builder.CopyTo(0, span, 1);
-    }
-
-    void StringBuilder_Equals_Span()
-    {
-        var builder = new StringBuilder("value");
+        builder.Append("suffix".AsSpan());
+        var targetSpan = new Span<char>(new char[1]);
+        builder.CopyTo(0, targetSpan, 1);
         var equals = builder.Equals("value".AsSpan());
-    }
-#endif
 
 #if NET6_0_OR_GREATER
-    void StringBuilder_Replace_ReadOnlySpan()
-    {
-        var builder = new StringBuilder();
-
         var result = builder.Replace("a".AsSpan(), "a".AsSpan());
         result = builder.Replace("a".AsSpan(), "a".AsSpan(), 1, 1);
+#endif
     }
 #endif
 
-    void Task_WaitAsync()
+    void Task_Methods()
     {
         var action = () =>
         {
@@ -525,12 +444,12 @@ class Consume
         new Task<int>(func).WaitAsync(TimeSpan.Zero, CancellationToken.None);
     }
 
-    void TaskCompletionSource_NonGeneric()
+    void TaskCompletionSource_NonGeneric_Methods()
     {
         var tcs = new TaskCompletionSource();
     }
 
-    void TaskCompletionSource_SetCanceled_WithCancellationToken()
+    void TaskCompletionSource_Generic_Methods()
     {
         var completionSource = new TaskCompletionSource<int>();
         var tokenSource = new CancellationTokenSource();
@@ -538,7 +457,7 @@ class Consume
     }
 
 #if FeatureMemory
-    async Task TextWriter()
+    async Task TextWriter_Methods()
     {
         TextWriter target = new StringWriter();
         target.Write(new StringBuilder());
@@ -549,17 +468,13 @@ class Consume
         await target.WriteAsync("a".AsMemory());
     }
 #endif
-    void Type_GetMemberWithSameMetadataDefinitionAs(MemberInfo info)
+    void Type_Methods(MemberInfo info)
     {
-        var result = typeof(string).GetMemberWithSameMetadataDefinitionAs(info);
-    }
-
-    void Type_IsGenericMethodParameter()
-    {
+        var member = typeof(string).GetMemberWithSameMetadataDefinitionAs(info);
         var result = typeof(string).IsGenericMethodParameter();
     }
 
-    void XDocument_SaveAsync()
+    void XDocument_Methods()
     {
         var document = new XDocument();
         document.SaveAsync(new XmlTextWriter(null!), CancellationToken.None);


### PR DESCRIPTION
Followup to https://github.com/SimonCropp/Polyfill/pull/211#issuecomment-2323583387.

I have made a new convention for API usages in Consume project, added it to `contributing.md` and modified `Consume.cs` according to the new convention.

Generally speaking, because Consume project is there only to check API compiles in old runtimes (net461 ect.), I think shorter code is preferable. The PR therefore puts method calls to method-per-type in a class (e.g. `Span_Methods` or  `Int_Methods`). I am using suffix to avoid naming issues where method and type have same name.