### PR TITLE
`WhiteSpaceChars`: always check `NET8_0`

### DIFF
--- a/src/Polyfill/Polyfill_Memory_SpanSplitEnumerator.cs
+++ b/src/Polyfill/Polyfill_Memory_SpanSplitEnumerator.cs
@@ -198,14 +198,11 @@ static partial class Polyfill
 
         const string whitespaces = "\t\n\v\f\r\u0020\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000";
 
-#if NET8_0_OR_GREATER
+#if NET8_0
         public static readonly SearchValues<char> WhiteSpaceChars =
             SearchValues.Create(whitespaces.AsSpan());
 #else
         public static readonly T[] WhiteSpaceChars;
-#endif
-
-#if !NET8_0
 
         static SpanSplitEnumerator()
         {
@@ -216,7 +213,6 @@ static partial class Polyfill
                     .ToArray();
             }
         }
-
 #endif
     }
 }


### PR DESCRIPTION
Was skimming #217 and found the single `NET8_0_OR_GREATER`. Since the whole file requires `!NET9_0_OR_GREATER`, that can be `NET8_0` like the related conditions.