### PR TITLE
Avoid closure capture in ConcurrentDictionary.GetOrAdd`3

### DIFF
--- a/api_list.include.md
+++ b/api_list.include.md
@@ -22,9 +22,9 @@
  * `Task CancelAsync(CancellationTokenSource)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.cancelasync)
 
 
-#### ConcurrentDictionary<TKey,TValue>
+#### ConcurrentDictionary<TKey, TValue>
 
- * `TValue GetOrAdd<TKey, TValue, TArg>(ConcurrentDictionary<TKey,TValue>, TKey, Func<TKey, TArg, TValue>, TArg) where TKey : notnull` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd#system-collections-concurrent-concurrentdictionary-2-getoradd-1(-0-system-func((-0-0-1))-0))
+ * `TValue GetOrAdd<TKey, TValue, TArg>(ConcurrentDictionary<TKey, TValue>, TKey, Func<TKey, TArg, TValue>, TArg) where TKey : notnull` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd#system-collections-concurrent-concurrentdictionary-2-getoradd-1(-0-system-func((-0-0-1))-0))
 
 
 #### DateOnly

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -218,7 +218,7 @@ class Consume
     void ConcurrentDictionary_Methods()
     {
         var dict = new ConcurrentDictionary<string, int>();
-        var value = dict.GetOrAdd("Hello", (_, arg) => arg.Length, "World");
+        var value = dict.GetOrAdd("Hello", static (_, arg) => arg.Length, "World");
     }
 
     void Dictionary_Methods()

--- a/src/Polyfill/Nullability/NullabilityInfoExtensions.cs
+++ b/src/Polyfill/Nullability/NullabilityInfoExtensions.cs
@@ -52,7 +52,7 @@ static partial class Polyfill
     }
 
     public static NullabilityInfo GetNullabilityInfo(this FieldInfo info) =>
-        fieldCache.GetOrAdd(info, inner =>
+        fieldCache.GetOrAdd(info, static inner =>
         {
             var context = new NullabilityInfoContext();
             return context.Create(inner);
@@ -68,7 +68,7 @@ static partial class Polyfill
     }
 
     public static NullabilityInfo GetNullabilityInfo(this EventInfo info) =>
-        eventCache.GetOrAdd(info, inner =>
+        eventCache.GetOrAdd(info, static inner =>
         {
             var context = new NullabilityInfoContext();
             return context.Create(inner);
@@ -86,7 +86,7 @@ static partial class Polyfill
     public static NullabilityInfo GetNullabilityInfo(this PropertyInfo info) =>
         propertyCache.GetOrAdd(
             info,
-            inner =>
+            static inner =>
             {
                 var context = new NullabilityInfoContext();
                 return context.Create(inner);
@@ -102,7 +102,7 @@ static partial class Polyfill
     }
 
     public static NullabilityInfo GetNullabilityInfo(this ParameterInfo info) =>
-        parameterCache.GetOrAdd(info, inner =>
+        parameterCache.GetOrAdd(info, static inner =>
         {
             var context = new NullabilityInfoContext();
             return context.Create(inner);

--- a/src/Polyfill/Polyfill_ConcurrentDictionary.cs
+++ b/src/Polyfill/Polyfill_ConcurrentDictionary.cs
@@ -25,12 +25,46 @@ static partial class Polyfill
     /// (Nothing in Visual Basic).</exception>
     /// <exception cref="OverflowException">The dictionary contains too many
     /// elements.</exception>
-    /// <returns>The value for the key.  This will be either the existing value for the key if the
+    /// <returns>The value for the key. This will be either the existing value for the key if the
     /// key is already in the dictionary, or the new value for the key as returned by valueFactory
     /// if the key was not in the dictionary.</returns>
     [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd#system-collections-concurrent-concurrentdictionary-2-getoradd-1(-0-system-func((-0-0-1))-0)")]
-    public static TValue GetOrAdd<TKey,TValue, TArg>(this ConcurrentDictionary<TKey,TValue> target, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
-        where TKey : notnull =>
-        target.GetOrAdd(key, _ => valueFactory(_, factoryArgument));
+    public static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> target, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        where TKey : notnull
+    {
+        // Implementation based on https://github.com/dotnet/runtime/issues/13978#issuecomment-69494764.
+        // Because this API is intended to be used in high performance scenarios where avoiding allocations
+        // is important, we can't delegate to the existing `GetOrAdd`2`, as that would allocate a closure
+        // over `factoryArgument`.
+
+        if (target is null)
+        {
+            throw new ArgumentNullException(nameof(target));
+        }
+
+        if (key is null)
+        {
+            throw new ArgumentNullException(nameof(target));
+        }
+        if (valueFactory is null)
+        {
+            throw new ArgumentNullException(nameof(valueFactory));
+        }
+
+        while (true)
+        {
+            TValue value;
+            if (target.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            value = valueFactory(key, factoryArgument);
+            if (target.TryAdd(key, value))
+            {
+                return value;
+            }
+        }
+    }
 }
 #endif

--- a/src/Tests/PolyfillTests_ConcurrentDictionary.cs
+++ b/src/Tests/PolyfillTests_ConcurrentDictionary.cs
@@ -5,7 +5,7 @@ partial class PolyfillTests
     {
         var dictionary = new ConcurrentDictionary<string, int>();
 
-        Func<string, string, int> valueFactory = (key, arg) => arg.Length;
+        Func<string, string, int> valueFactory = static (key, arg) => arg.Length;
 
         var value = dictionary.GetOrAdd("Hello", valueFactory, "World");
 


### PR DESCRIPTION
ConcurrentDictionary.GetOrAdd`3 is intended for high performance scenarios where avoiding allocation is important. However, the old implementation delegated to GetOrAdd`2, which allocates a closure for factoryArgument.

Update the implementation to avoid the closure allocation using the suggested implementation from https://github.com/dotnet/runtime/issues/13978#issuecomment-69494764.

Additionally, I did an audit of existing GetOrAdd`3 calls and used the `static` modifier to prevent accidental capture.