### PR TITLE
Remove link attribute and use a comment instead

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -160,7 +160,7 @@ using Link = System.ComponentModel.DescriptionAttribute;
 /// The specification for module initializers in the .NET runtime can be found here:
 /// https://github.com/dotnet/runtime/blob/master/docs/design/specs/Ecma-335-Augments.md#module-initializer
 /// </remarks>
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(
@@ -216,7 +216,7 @@ static partial class Polyfill
     /// <returns>A <see cref="Task"/> that represents the asynchronous flush operation.</returns>
     /// <exception cref="ObjectDisposedException">The text writer is disposed.</exception>
     /// <exception cref="InvalidOperationException">The writer is currently in use by a previous write operation.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flushasync#system-io-textwriter-flushasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flushasync#system-io-textwriter-flushasync(system-threading-cancellationtoken)
     public static Task FlushAsync(this TextWriter target, CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
@@ -236,7 +236,7 @@ static partial class Polyfill
     /// StringBuilder.GetChunks() method to avoid creating the intermediate string
     /// </summary>
     /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-text-stringbuilder)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-text-stringbuilder)
     public static void Write(this TextWriter target, StringBuilder? value)
     {
         if (value == null)
@@ -260,7 +260,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)
     public static Task WriteAsync(this TextWriter target, StringBuilder? value, CancellationToken cancellationToken = default)
     {
         if (cancellationToken.IsCancellationRequested)
@@ -302,7 +302,7 @@ static partial class Polyfill
     /// The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)
     public static ValueTask WriteAsync(
         this TextWriter target,
         ReadOnlyMemory<char> buffer,
@@ -330,7 +330,7 @@ static partial class Polyfill
     /// The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync#system-io-textwriter-writelineasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync#system-io-textwriter-writelineasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)
     public static ValueTask WriteLineAsync(
         this TextWriter target,
         ReadOnlyMemory<char> buffer,
@@ -355,7 +355,7 @@ static partial class Polyfill
     /// Writes a character span to the text stream.
     /// </summary>
     /// <param name="buffer">The character span to write.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-readonlyspan((system-char)))
     public static void Write(
         this TextWriter target,
         ReadOnlySpan<char> buffer)
@@ -378,7 +378,7 @@ static partial class Polyfill
     /// Writes the text representation of a character span to the text stream, followed by a line terminator.
     /// </summary>
     /// <param name="buffer">The char span value to write to the text stream.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline#system-io-textwriter-writeline(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline#system-io-textwriter-writeline(system-readonlyspan((system-char)))
     public static void WriteLine(
         this TextWriter target,
         ReadOnlySpan<char> buffer)

--- a/readme.md
+++ b/readme.md
@@ -842,7 +842,7 @@ The class `Polyfill` includes the following extension methods:
 
 #### Type
 
- * `MethodInfo? GetMethod(string, int, BindingFlags, Type[])`
+ * `MethodInfo? GetMethod(string, int, BindingFlags, Type[])` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethod#system-type-getmethod(system-string-system-int32-system-reflection-bindingflags-system-type()))
  * `bool IsAssignableFrom<T>()`
  * `bool IsAssignableTo<T>()`
  * `bool IsAssignableTo(Type?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.type.isassignableto)

--- a/readme.md
+++ b/readme.md
@@ -478,7 +478,7 @@ The class `Polyfill` includes the following extension methods:
 
 #### ConcurrentBag<T>
 
- * `void Clear<T>(ConcurrentBag<T>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentbag-1.clear)
+ * `void Clear<T>()` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentbag-1.clear)
 
 
 #### ConcurrentDictionary<TKey, TValue>
@@ -842,7 +842,7 @@ The class `Polyfill` includes the following extension methods:
 
 #### Type
 
- * `MethodInfo? GetMethod(string, int, BindingFlags, Type[])` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethod#system-type-getmethod(system-string-system-int32-system-reflection-bindingflags-system-type()))
+ * `MethodInfo? GetMethod(string, int, BindingFlags, Type[])`
  * `bool IsAssignableFrom<T>()`
  * `bool IsAssignableTo<T>()`
  * `bool IsAssignableTo(Type?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.type.isassignableto)

--- a/src/ApiBuilderTests/BuildApiTest.cs
+++ b/src/ApiBuilderTests/BuildApiTest.cs
@@ -212,7 +212,7 @@ class BuildApiTest
             if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
             {
                 var comment = trivia.ToString();
-                if (comment.Contains("Link:"))
+                if (comment.StartsWith("//Link: "))
                 {
                     reference = comment.Replace("//Link: ", string.Empty);
                     return true;

--- a/src/ApiBuilderTests/BuildApiTest.cs
+++ b/src/ApiBuilderTests/BuildApiTest.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+
 [TestFixture]
 class BuildApiTest
 {
@@ -204,16 +206,22 @@ class BuildApiTest
 
     static bool TryGetReference(MethodDeclarationSyntax method, [NotNullWhen(true)] out string? reference)
     {
-        var descriptionAttribute = method.Attributes()
-            .SingleOrDefault(_ => _.Name.ToString() == "Link");
-        if (descriptionAttribute == null)
+        var syntaxTrivia = method.GetLeadingTrivia();
+        foreach (var trivia in syntaxTrivia)
         {
-            reference = null;
-            return false;
+            if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
+            {
+                var comment = trivia.ToString();
+                if (comment.Contains("Link:"))
+                {
+                    reference = comment.Replace("//Link: ", string.Empty);
+                    return true;
+                }
+            }
         }
 
-        reference = descriptionAttribute.ArgumentList!.Arguments.Single().Value().Trim('"');
-        return true;
+        reference = null;
+        return false;
     }
 
 

--- a/src/Polyfill/CallerArgumentExpressionAttribute.cs
+++ b/src/Polyfill/CallerArgumentExpressionAttribute.cs
@@ -15,7 +15,7 @@ using Link = ComponentModel.DescriptionAttribute;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.callerargumentexpressionattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.callerargumentexpressionattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/CollectionBuilderAttribute.cs
+++ b/src/Polyfill/CollectionBuilderAttribute.cs
@@ -12,7 +12,7 @@ using Link = ComponentModel.DescriptionAttribute;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.collectionbuilderattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.collectionbuilderattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/CompilerFeatureRequiredAttribute.cs
+++ b/src/Polyfill/CompilerFeatureRequiredAttribute.cs
@@ -18,7 +18,7 @@ using Link = ComponentModel.DescriptionAttribute;
     validOn: AttributeTargets.All,
     AllowMultiple = true,
     Inherited = false)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.compilerfeaturerequiredattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.compilerfeaturerequiredattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/ConstantExpectedAttribute.cs
+++ b/src/Polyfill/ConstantExpectedAttribute.cs
@@ -18,7 +18,7 @@ using Link = ComponentModel.DescriptionAttribute;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.constantexpectedattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.constantexpectedattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/DateTimeOffsetPolyfill.cs
+++ b/src/Polyfill/DateTimeOffsetPolyfill.cs
@@ -21,7 +21,7 @@ static class DateTimeOffsetPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-string-system-iformatprovider-system-datetimeoffset@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-string-system-iformatprovider-system-datetimeoffset@)
     public static bool TryParse(string? target, IFormatProvider? provider, out DateTimeOffset result) =>
 #if NET7_0_OR_GREATER
         DateTimeOffset.TryParse(target, provider, out result);
@@ -34,7 +34,7 @@ static class DateTimeOffsetPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-datetimeoffset@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-datetimeoffset@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out DateTimeOffset result) =>
 #if NET8_0_OR_GREATER
         DateTimeOffset.TryParse(target, provider, out result);
@@ -45,7 +45,7 @@ static class DateTimeOffsetPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-readonlyspan((system-char))-system-datetimeoffset@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-readonlyspan((system-char))-system-datetimeoffset@)
     public static bool TryParse(ReadOnlySpan<char> target, out DateTimeOffset result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         DateTimeOffset.TryParse(target, out result);
@@ -56,7 +56,7 @@ static class DateTimeOffsetPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetimeoffset@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparse#system-datetimeoffset-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetimeoffset@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, DateTimeStyles styles, out DateTimeOffset result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         DateTimeOffset.TryParse(target, provider, styles, out result);
@@ -67,7 +67,7 @@ static class DateTimeOffsetPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparseexact#system-datetimeoffset-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetimeoffset@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparseexact#system-datetimeoffset-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetimeoffset@)
     public static bool TryParseExact(ReadOnlySpan<char> target, string format, IFormatProvider? provider, DateTimeStyles styles, out DateTimeOffset result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         DateTimeOffset.TryParseExact(target, format, provider, styles, out result);
@@ -78,7 +78,7 @@ static class DateTimeOffsetPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparseexact#system-datetimeoffset-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetimeoffset@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparseexact#system-datetimeoffset-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetimeoffset@)
     public static bool TryParseExact(ReadOnlySpan<char> target, ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles styles, out DateTimeOffset result) =>
 #if NETFRAMEWORK || NETSTANDARD2_0 || NETCOREAPP2_0
         DateTimeOffset.TryParseExact(target.ToString(), format.ToString(), provider, styles, out result);

--- a/src/Polyfill/DateTimePolyfill.cs
+++ b/src/Polyfill/DateTimePolyfill.cs
@@ -19,7 +19,7 @@ static class DateTimePolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-string-system-iformatprovider-system-datetime@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-string-system-iformatprovider-system-datetime@)
     public static bool TryParse(string? target, IFormatProvider? provider, out DateTime result) =>
 #if NET7_0_OR_GREATER
         DateTime.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class DateTimePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-datetime@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-datetime@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out DateTime result) =>
 #if NET8_0_OR_GREATER
         DateTime.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class DateTimePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-readonlyspan((system-char))-system-datetime@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-readonlyspan((system-char))-system-datetime@)
     public static bool TryParse(ReadOnlySpan<char> target, out DateTime result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         DateTime.TryParse(target, out result);
@@ -54,7 +54,7 @@ static class DateTimePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetime@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparse#system-datetime-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetime@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, DateTimeStyles styles, out DateTime result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         DateTime.TryParse(target, provider, styles, out result);
@@ -65,7 +65,7 @@ static class DateTimePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparseexact#system-datetime-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetime@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparseexact#system-datetime-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetime@)
     public static bool TryParseExact(ReadOnlySpan<char> target, string format, IFormatProvider? provider, DateTimeStyles style, out DateTime result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         DateTime.TryParseExact(target, format, provider, style, out result);
@@ -76,7 +76,7 @@ static class DateTimePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparseexact#system-datetime-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetime@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryparseexact#system-datetime-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-iformatprovider-system-globalization-datetimestyles-system-datetime@)
     public static bool TryParseExact(ReadOnlySpan<char> target, ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles styles, out DateTime result) =>
 #if NETFRAMEWORK || NETSTANDARD2_0 || NETCOREAPP2_0
         DateTime.TryParseExact(target.ToString(), format.ToString(), provider, styles, out result);

--- a/src/Polyfill/DisableRuntimeMarshallingAttribute.cs
+++ b/src/Polyfill/DisableRuntimeMarshallingAttribute.cs
@@ -29,7 +29,7 @@ using Link = ComponentModel.DescriptionAttribute;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Assembly)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.disableruntimemarshallingattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.disableruntimemarshallingattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/EnumPolyfill.cs
+++ b/src/Polyfill/EnumPolyfill.cs
@@ -20,7 +20,7 @@ static class EnumPolyfill
     /// Retrieves an array of the values of the constants in a specified enumeration type.
     /// </summary>
     /// <returns>An array that contains the values of the constants in TEnum.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.getvalues")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.getvalues
     public static TEnum[] GetValues<TEnum>()
         where TEnum : struct, Enum
     {
@@ -38,8 +38,8 @@ static class EnumPolyfill
     /// <typeparam name="TEnum">The type of the enumeration.</typeparam>
     /// <param name="value">The value in <typeparamref name="TEnum"/>.</param>
     /// <returns><see langword="true"/> if a given integral value exists in a specified enumeration; <see langword="false"/>, otherwise.</returns>
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.isdefined#system-enum-isdefined-1(-0)
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.isdefined#system-enum-isdefined-1(-0)")]
     public static bool IsDefined<TEnum> (TEnum value)
         where TEnum : struct, Enum =>
 #if NET5_0_OR_GREATER
@@ -52,7 +52,7 @@ static class EnumPolyfill
     /// Retrieves an array of the names of the constants in a specified enumeration type.
     /// </summary>
     /// <returns>A string array of the names of the constants in TEnum.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.getnames")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.getnames
     public static string[] GetNames<TEnum>()
         where TEnum : struct, Enum =>
 #if NETCOREAPPX || NETFRAMEWORK || NETSTANDARD
@@ -64,7 +64,7 @@ static class EnumPolyfill
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more enumerated constants specified by TEnum to an equivalent enumerated object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-string-system-boolean)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-string-system-boolean)
     public static TEnum Parse<TEnum>(string value)
         where TEnum : struct, Enum =>
 #if NETFRAMEWORK || NETSTANDARD
@@ -76,7 +76,7 @@ static class EnumPolyfill
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more enumerated constants specified by TEnum to an equivalent enumerated object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-string-system-boolean)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-string-system-boolean)
     public static TEnum Parse<TEnum>(string value, bool ignoreCase)
         where TEnum : struct, Enum =>
 #if NETFRAMEWORK || NETSTANDARD
@@ -90,7 +90,7 @@ static class EnumPolyfill
     /// <summary>
     /// Converts the span of characters representation of the name or numeric value of one or more enumerated constants specified by TEnum to an equivalent enumerated object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-readonlyspan((system-char)))
     public static TEnum Parse<TEnum>(ReadOnlySpan<char> value)
         where TEnum : struct, Enum =>
 #if NET6_0_OR_GREATER
@@ -102,7 +102,7 @@ static class EnumPolyfill
     /// <summary>
     /// Converts the span of characters representation of the name or numeric value of one or more enumerated constants specified by TEnum to an equivalent enumerated object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-readonlyspan((system-char))-system-boolean)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse#system-enum-parse-1(system-readonlyspan((system-char))-system-boolean)
     public static TEnum Parse<TEnum>(ReadOnlySpan<char> value, bool ignoreCase)
         where TEnum : struct, Enum =>
 #if NET6_0_OR_GREATER
@@ -114,7 +114,7 @@ static class EnumPolyfill
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.tryparse#system-enum-tryparse-1(system-readonlyspan((system-char))-0@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.tryparse#system-enum-tryparse-1(system-readonlyspan((system-char))-0@)
     public static bool TryParse<TEnum>(ReadOnlySpan<char> value, out TEnum result)
         where TEnum : struct, Enum =>
 #if NET6_0_OR_GREATER
@@ -126,7 +126,7 @@ static class EnumPolyfill
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object. A parameter specifies whether the operation is case-sensitive. The return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.enum.tryparse#system-enum-tryparse-1(system-readonlyspan((system-char))-system-boolean-0@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.enum.tryparse#system-enum-tryparse-1(system-readonlyspan((system-char))-system-boolean-0@)
     public static bool TryParse<TEnum>(ReadOnlySpan<char> value, bool ignoreCase, out TEnum result)
         where TEnum : struct, Enum =>
 #if NET6_0_OR_GREATER

--- a/src/Polyfill/ExperimentalAttribute.cs
+++ b/src/Polyfill/ExperimentalAttribute.cs
@@ -34,7 +34,7 @@ using Link = ComponentModel.DescriptionAttribute;
                 AttributeTargets.Delegate, Inherited = false)]
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/GuidPolyfill.cs
+++ b/src/Polyfill/GuidPolyfill.cs
@@ -18,7 +18,7 @@ static class GuidPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparse#system-guid-tryparse(system-string-system-iformatprovider-system-guid@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparse#system-guid-tryparse(system-string-system-iformatprovider-system-guid@)
     public static bool TryParse(string? target, IFormatProvider? provider, out Guid result) =>
 #if NET7_0_OR_GREATER
         Guid.TryParse(target, provider, out result);
@@ -31,7 +31,7 @@ static class GuidPolyfill
     /// <summary>
     /// Converts span of characters representing the GUID to the equivalent Guid structure, provided that the string is in the specified format.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparseexact#system-guid-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-guid@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparseexact#system-guid-tryparseexact(system-readonlyspan((system-char))-system-readonlyspan((system-char))-system-guid@)
     public static bool TryParseExact(ReadOnlySpan<char> target, ReadOnlySpan<char> format, out Guid result) =>
 #if NETFRAMEWORK || NETCOREAPP2_0 || NETSTANDARD2_0
         Guid.TryParseExact(target.ToString(), format.ToString(), out result);
@@ -42,7 +42,7 @@ static class GuidPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparse#system-guid-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-guid@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparse#system-guid-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-guid@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out Guid result) =>
 #if NET7_0_OR_GREATER
         Guid.TryParse(target, provider, out result);
@@ -53,7 +53,7 @@ static class GuidPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparse?view=net-8.0#system-guid-tryparse(system-readonlyspan((system-char))-system-guid@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryparse?view=net-8.0#system-guid-tryparse(system-readonlyspan((system-char))-system-guid@)
     public static bool TryParse(ReadOnlySpan<char> target, out Guid result) =>
 #if NETSTANDARD2_1 || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         Guid.TryParse(target, out result);

--- a/src/Polyfill/Lock.cs
+++ b/src/Polyfill/Lock.cs
@@ -22,7 +22,7 @@ using Link = ComponentModel.DescriptionAttribute;
 /// </remarks>
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.lock")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.lock
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/ModuleInitializerAttribute.cs
+++ b/src/Polyfill/ModuleInitializerAttribute.cs
@@ -29,7 +29,7 @@ using Link = System.ComponentModel.DescriptionAttribute;
 /// The specification for module initializers in the .NET runtime can be found here:
 /// https://github.com/dotnet/runtime/blob/master/docs/design/specs/Ecma-335-Augments.md#module-initializer
 /// </remarks>
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(

--- a/src/Polyfill/Nullability/NullabilityInfo.cs
+++ b/src/Polyfill/Nullability/NullabilityInfo.cs
@@ -19,7 +19,7 @@ using Link = ComponentModel.DescriptionAttribute;
 /// </summary>
 [DebuggerNonUserCode]
 [ExcludeFromCodeCoverage]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.reflection.nullabilityinfo?view=net-8.0")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.reflection.nullabilityinfo?view=net-8.0
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/Numbers/BytePolyfill.cs
+++ b/src/Polyfill/Numbers/BytePolyfill.cs
@@ -21,7 +21,7 @@ static class BytePolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-string-system-iformatprovider-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-string-system-iformatprovider-system-byte@)
     public static bool TryParse(string? target, IFormatProvider? provider, out byte result) =>
 #if NET7_0_OR_GREATER
         byte.TryParse(target, provider, out result);
@@ -33,7 +33,7 @@ static class BytePolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-byte@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out byte result) =>
 #if NET8_0_OR_GREATER
         byte.TryParse(target, provider, out result);
@@ -44,7 +44,7 @@ static class BytePolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its byte equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-byte@)
     public static bool TryParse(ReadOnlySpan<char> target, out byte result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         byte.TryParse(target.ToString(), out result);
@@ -55,7 +55,7 @@ static class BytePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-byte@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out byte result) =>
 #if NET7_0_OR_GREATER
         byte.TryParse(target, provider, out result);
@@ -66,7 +66,7 @@ static class BytePolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-byte@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out byte result) =>
 #if NET8_0_OR_GREATER
         byte.TryParse(target, style, provider, out result);
@@ -77,7 +77,7 @@ static class BytePolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its byte equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-byte@)
     public static bool TryParse(ReadOnlySpan<byte> target, out byte result) =>
 #if NET8_0_OR_GREATER
         byte.TryParse(target, out result);
@@ -88,7 +88,7 @@ static class BytePolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its byte equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-byte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryparse#system-byte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-byte@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out byte result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         byte.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/DoublePolyfill.cs
+++ b/src/Polyfill/Numbers/DoublePolyfill.cs
@@ -20,7 +20,7 @@ static class DoublePolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-string-system-iformatprovider-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-string-system-iformatprovider-system-double@)
     public static bool TryParse(string? target, IFormatProvider? provider, out double result) =>
 #if NET7_0_OR_GREATER
         double.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class DoublePolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-double@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out double result) =>
 #if NET8_0_OR_GREATER
         double.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class DoublePolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its double-precision floating-point number equivalent. A return value indicates whether the conversion succeeded or failed.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-char))-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-char))-system-double@)
     public static bool TryParse(ReadOnlySpan<char> target, out double result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         double.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class DoublePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-double@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out double result) =>
 #if NET7_0_OR_GREATER
         double.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class DoublePolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-double@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out double result) =>
 #if NET8_0_OR_GREATER
         double.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class DoublePolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its double-precision floating-point number equivalent..
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-byte))-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-byte))-system-double@)
     public static bool TryParse(ReadOnlySpan<byte> target, out double result) =>
 #if NET8_0_OR_GREATER
         double.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class DoublePolyfill
     /// <summary>
     /// Converts the string representation of a number in a specified style and culture-specific format to its double-precision floating-point number equivalent. A return value indicates whether the conversion succeeded or failed.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-double@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryparse#system-double-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-double@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out double result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         double.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/IntPolyfill.cs
+++ b/src/Polyfill/Numbers/IntPolyfill.cs
@@ -20,7 +20,7 @@ static class IntPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-string-system-iformatprovider-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-string-system-iformatprovider-system-int32@)
     public static bool TryParse(string? target, IFormatProvider? provider, out int result) =>
 #if NET7_0_OR_GREATER
         int.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class IntPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-int32@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out int result) =>
 #if NET8_0_OR_GREATER
         int.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class IntPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed integer equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-int32@)
     public static bool TryParse(ReadOnlySpan<char> target, out int result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         int.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class IntPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-int32@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out int result) =>
 #if NET7_0_OR_GREATER
         int.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class IntPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-int32@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out int result) =>
 #if NET8_0_OR_GREATER
         int.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class IntPolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its 32-bit signed integer equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int32@)
     public static bool TryParse(ReadOnlySpan<byte> target, out int result) =>
 #if NET8_0_OR_GREATER
         int.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class IntPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed integer equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse#system-int32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int32@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out int result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         int.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/LongPolyfill.cs
+++ b/src/Polyfill/Numbers/LongPolyfill.cs
@@ -20,7 +20,7 @@ static class LongPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-string-system-iformatprovider-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-string-system-iformatprovider-system-int64@)
     public static bool TryParse(string? target, IFormatProvider? provider, out int result) =>
 #if NET7_0_OR_GREATER
         int.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class LongPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-int64@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out int result) =>
 #if NET8_0_OR_GREATER
         int.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class LongPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed integer equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-int64@)
     public static bool TryParse(ReadOnlySpan<char> target, out int result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         int.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class LongPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-int64@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out int result) =>
 #if NET7_0_OR_GREATER
         int.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class LongPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-int64@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out int result) =>
 #if NET8_0_OR_GREATER
         int.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class LongPolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its 64-bit signed integer equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int64@)
     public static bool TryParse(ReadOnlySpan<byte> target, out int result) =>
 #if NET8_0_OR_GREATER
         int.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class LongPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed integer equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryparse#system-int64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int64@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out int result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         int.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/SBytePolyfill.cs
+++ b/src/Polyfill/Numbers/SBytePolyfill.cs
@@ -20,7 +20,7 @@ static class SBytePolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-string-system-iformatprovider-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-string-system-iformatprovider-system-sbyte@)
     public static bool TryParse(string? target, IFormatProvider? provider, out sbyte result) =>
 #if NET7_0_OR_GREATER
         sbyte.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class SBytePolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-sbyte@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out sbyte result) =>
 #if NET8_0_OR_GREATER
         sbyte.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class SBytePolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its sbyte equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-sbyte@)
     public static bool TryParse(ReadOnlySpan<char> target, out sbyte result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         sbyte.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class SBytePolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-sbyte@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out sbyte result) =>
 #if NET7_0_OR_GREATER
         sbyte.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class SBytePolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-sbyte@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out sbyte result) =>
 #if NET8_0_OR_GREATER
         sbyte.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class SBytePolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its sbyte equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-sbyte@)
     public static bool TryParse(ReadOnlySpan<byte> target, out sbyte result) =>
 #if NET8_0_OR_GREATER
         sbyte.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class SBytePolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its sbyte equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-sbyte@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryparse#system-sbyte-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-sbyte@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out sbyte result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         sbyte.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/ShortPolyfill.cs
+++ b/src/Polyfill/Numbers/ShortPolyfill.cs
@@ -20,7 +20,7 @@ static class ShortPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-string-system-iformatprovider-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-string-system-iformatprovider-system-int16@)
     public static bool TryParse(string? target, IFormatProvider? provider, out short result) =>
 #if NET7_0_OR_GREATER
         short.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class ShortPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-int16@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out short result) =>
 #if NET8_0_OR_GREATER
         short.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class ShortPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its short equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-int16@)
     public static bool TryParse(ReadOnlySpan<char> target, out short result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         short.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class ShortPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-int16@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out short result) =>
 #if NET7_0_OR_GREATER
         short.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class ShortPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-int16@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out short result) =>
 #if NET8_0_OR_GREATER
         short.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class ShortPolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its short equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int16@)
     public static bool TryParse(ReadOnlySpan<byte> target, out short result) =>
 #if NET8_0_OR_GREATER
         short.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class ShortPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its short equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryparse#system-int16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-int16@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out short result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         short.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/UIntPolyfill.cs
+++ b/src/Polyfill/Numbers/UIntPolyfill.cs
@@ -20,7 +20,7 @@ static class UIntPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-string-system-iformatprovider-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-string-system-iformatprovider-system-uint32@)
     public static bool TryParse(string? target, IFormatProvider? provider, out uint result) =>
 #if NET7_0_OR_GREATER
         uint.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class UIntPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-uint32@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out uint result) =>
 #if NET8_0_OR_GREATER
         uint.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class UIntPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its uint equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-uint32@)
     public static bool TryParse(ReadOnlySpan<char> target, out uint result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         uint.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class UIntPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-uint32@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out uint result) =>
 #if NET7_0_OR_GREATER
         uint.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class UIntPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-uint32@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out uint result) =>
 #if NET8_0_OR_GREATER
         uint.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class UIntPolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its uint equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint32@)
     public static bool TryParse(ReadOnlySpan<byte> target, out uint result) =>
 #if NET8_0_OR_GREATER
         uint.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class UIntPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its uint equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint32@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryparse#system-uint32-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint32@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out uint result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         uint.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/ULongPolyfill.cs
+++ b/src/Polyfill/Numbers/ULongPolyfill.cs
@@ -20,7 +20,7 @@ static class ULongPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-string-system-iformatprovider-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-string-system-iformatprovider-system-uint64@)
     public static bool TryParse(string? target, IFormatProvider? provider, out ulong result) =>
 #if NET7_0_OR_GREATER
         ulong.TryParse(target, provider, out result);
@@ -32,7 +32,7 @@ static class ULongPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-uint64@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out ulong result) =>
 #if NET8_0_OR_GREATER
         ulong.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class ULongPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its ulong equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-uint64@)
     public static bool TryParse(ReadOnlySpan<char> target, out ulong result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         ulong.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class ULongPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-uint64@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out ulong result) =>
 #if NET7_0_OR_GREATER
         ulong.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class ULongPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-uint64@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out ulong result) =>
 #if NET8_0_OR_GREATER
         ulong.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class ULongPolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its ulong equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint64@)
     public static bool TryParse(ReadOnlySpan<byte> target, out ulong result) =>
 #if NET8_0_OR_GREATER
         ulong.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class ULongPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its ulong equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint64@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryparse#system-uint64-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint64@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out ulong result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         ulong.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/Numbers/UShortPolyfill.cs
+++ b/src/Polyfill/Numbers/UShortPolyfill.cs
@@ -20,7 +20,7 @@ static class UShortPolyfill
     /// <summary>
     /// Tries to parse a string into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-string-system-iformatprovider-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-string-system-iformatprovider-system-uint16@)
     public static bool TryParse(string? target, IFormatProvider? provider, out ushort result) =>
 #if !NET7_0_OR_GREATER
         ushort.TryParse(target, NumberStyles.Integer, provider, out result);
@@ -32,7 +32,7 @@ static class UShortPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-byte))-system-iformatprovider-system-uint16@)
     public static bool TryParse(ReadOnlySpan<byte> target, IFormatProvider? provider, out ushort result) =>
 #if NET8_0_OR_GREATER
         ushort.TryParse(target, provider, out result);
@@ -43,7 +43,7 @@ static class UShortPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its ushort equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-uint16@)
     public static bool TryParse(ReadOnlySpan<char> target, out ushort result) =>
 #if NETCOREAPP2_0 || NETFRAMEWORK || NETSTANDARD2_0
         ushort.TryParse(target.ToString(), out result);
@@ -54,7 +54,7 @@ static class UShortPolyfill
     /// <summary>
     /// Tries to parse a span of characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-iformatprovider-system-uint16@)
     public static bool TryParse(ReadOnlySpan<char> target, IFormatProvider? provider, out ushort result) =>
 #if NET7_0_OR_GREATER
         ushort.TryParse(target, provider, out result);
@@ -65,7 +65,7 @@ static class UShortPolyfill
     /// <summary>
     /// Tries to parse a span of UTF-8 characters into a value.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-byte))-system-globalization-numberstyles-system-iformatprovider-system-uint16@)
     public static bool TryParse(ReadOnlySpan<byte> target, NumberStyles style, IFormatProvider? provider, out ushort result) =>
 #if NET8_0_OR_GREATER
         ushort.TryParse(target, style, provider, out result);
@@ -76,7 +76,7 @@ static class UShortPolyfill
     /// <summary>
     /// Tries to convert a UTF-8 character span containing the string representation of a number to its ushort equivalent.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint16@)
     public static bool TryParse(ReadOnlySpan<byte> target, out ushort result) =>
 #if NET8_0_OR_GREATER
         ushort.TryParse(target, out result);
@@ -87,7 +87,7 @@ static class UShortPolyfill
     /// <summary>
     /// Converts the span representation of a number in a specified style and culture-specific format to its ushort equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint16@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryparse#system-uint16-tryparse(system-readonlyspan((system-char))-system-globalization-numberstyles-system-iformatprovider-system-uint16@)
     public static bool TryParse(ReadOnlySpan<char> target, NumberStyles style, IFormatProvider? provider, out ushort result) =>
 #if NETCOREAPP2_0 || NETSTANDARD2_0 || NETFRAMEWORK
         ushort.TryParse(target.ToString(), style, provider, out result);

--- a/src/Polyfill/OverloadResolutionPriorityAttribute.cs
+++ b/src/Polyfill/OverloadResolutionPriorityAttribute.cs
@@ -19,7 +19,7 @@ using Link = ComponentModel.DescriptionAttribute;
     AttributeTargets.Constructor |
     AttributeTargets.Property,
     Inherited = false)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.overloadresolutionpriorityattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.overloadresolutionpriorityattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/Polyfill_CancellationToken.cs
+++ b/src/Polyfill/Polyfill_CancellationToken.cs
@@ -32,7 +32,7 @@ static partial class Polyfill
     /// <returns>The <see cref="CancellationTokenRegistration"/> instance that can
     /// be used to unregister the callback.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="callback"/> is null.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.unsaferegister#system-threading-cancellationtoken-unsaferegister(system-action((system-object))-system-object)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.unsaferegister#system-threading-cancellationtoken-unsaferegister(system-action((system-object))-system-object)
     public static CancellationTokenRegistration UnsafeRegister(this CancellationToken target, Action<object?> callback, object? state)
     {
         if (callback is null)
@@ -79,7 +79,7 @@ static partial class Polyfill
     /// <param name="state">The state to pass to the <paramref name="callback"/> when the delegate is invoked.  This may be null.</param>
     /// <returns>The <see cref="CancellationTokenRegistration"/> instance that can be used to unregister the callback.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="callback"/> is null.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.register#system-threading-cancellationtoken-register(system-action((system-object-system-threading-cancellationtoken))-system-object)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.register#system-threading-cancellationtoken-register(system-action((system-object-system-threading-cancellationtoken))-system-object)
     public static CancellationTokenRegistration Register(this CancellationToken target, Action<object?, CancellationToken> callback, object? state)
     {
         if (callback is null)
@@ -99,7 +99,7 @@ static partial class Polyfill
     /// <param name="state">The state to pass to the <paramref name="callback"/> when the delegate is invoked.  This may be null.</param>
     /// <returns>The <see cref="CancellationTokenRegistration"/> instance that can be used to unregister the callback.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="callback"/> is null.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.unsaferegister#system-threading-cancellationtoken-unsaferegister(system-action((system-object-system-threading-cancellationtoken))-system-object)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.unsaferegister#system-threading-cancellationtoken-unsaferegister(system-action((system-object-system-threading-cancellationtoken))-system-object)
     public static CancellationTokenRegistration UnsafeRegister(this CancellationToken target, Action<object?, CancellationToken> callback, object? state)
     {
         if (callback is null)

--- a/src/Polyfill/Polyfill_CancellationTokenSource.cs
+++ b/src/Polyfill/Polyfill_CancellationTokenSource.cs
@@ -32,7 +32,7 @@ static partial class Polyfill
     /// </para>
     /// </remarks>
     /// <exception cref="ObjectDisposedException">This <see cref="CancellationTokenSource"/> has been disposed.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.cancelasync")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.cancelasync
     public static Task CancelAsync(this CancellationTokenSource target)
     {
         if (target.IsCancellationRequested)

--- a/src/Polyfill/Polyfill_ConcurrentBag.cs
+++ b/src/Polyfill/Polyfill_ConcurrentBag.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
     /// <summary>
     /// Removes all values from the <see cref="ConcurrentBag{T}"/>.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentbag-1.clear")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentbag-1.clear
     public static void Clear<T>(this ConcurrentBag<T> target)
     {
         while (!target.IsEmpty)

--- a/src/Polyfill/Polyfill_ConcurrentDictionary.cs
+++ b/src/Polyfill/Polyfill_ConcurrentDictionary.cs
@@ -28,7 +28,7 @@ static partial class Polyfill
     /// <returns>The value for the key. This will be either the existing value for the key if the
     /// key is already in the dictionary, or the new value for the key as returned by valueFactory
     /// if the key was not in the dictionary.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd#system-collections-concurrent-concurrentdictionary-2-getoradd-1(-0-system-func((-0-0-1))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd#system-collections-concurrent-concurrentdictionary-2-getoradd-1(-0-system-func((-0-0-1))-0)
     public static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> target, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
         where TKey : notnull
     {

--- a/src/Polyfill/Polyfill_ConcurrentQueue.cs
+++ b/src/Polyfill/Polyfill_ConcurrentQueue.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
     /// <summary>
     /// Removes all values from the <see cref="ConcurrentQueue{T}"/>.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentqueue-1.clear")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentqueue-1.clear
     public static void Clear<T>(this ConcurrentQueue<T> target)
     {
         while (target.TryDequeue(out _));

--- a/src/Polyfill/Polyfill_Dictionary.cs
+++ b/src/Polyfill/Polyfill_Dictionary.cs
@@ -20,7 +20,7 @@ static partial class Polyfill
     /// <param name="dictionary">The dictionary to wrap.</param>
     /// <returns>An object that acts as a read-only wrapper around the current <see cref="IDictionary{TKey, TValue}"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is null.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.asreadonly#system-collections-generic-collectionextensions-asreadonly-2(system-collections-generic-idictionary((-0-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.asreadonly#system-collections-generic-collectionextensions-asreadonly-2(system-collections-generic-idictionary((-0-1)))
     public static ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> target)
         where TKey : notnull =>
         new(target);
@@ -35,7 +35,7 @@ static partial class Polyfill
     /// <param name="value">The value of the element to add. It can be <see langword="null"/>.</param>
     /// <returns><c>true</c> if the key/value pair was added to the dictionary successfully; otherwise, <c>false</c>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.tryadd")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.tryadd
     public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> target, TKey key, TValue value)
         where TKey : notnull
     {
@@ -68,7 +68,7 @@ static partial class Polyfill
     /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
     /// <returns><code>true</code> if the element is successfully found and removed; otherwise, <code>false</code>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="key"/> is <code>null</code>.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.remove")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.remove
     public static bool Remove<TKey, TValue>(
         this Dictionary<TKey, TValue> target,
         TKey key,

--- a/src/Polyfill/Polyfill_HashSet.cs
+++ b/src/Polyfill/Polyfill_HashSet.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// <param name="equalValue">The value to search for.</param>
     /// <param name="actualValue">The value from the set that the search found, or the default value of T when the search yielded no match.</param>
     /// <returns>A value indicating whether the search was successful.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.trygetvalue")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.trygetvalue
     public static bool TryGetValue<T>(
         this HashSet<T> target,
         T equalValue,

--- a/src/Polyfill/Polyfill_HttpClient.cs
+++ b/src/Polyfill/Polyfill_HttpClient.cs
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// <param name="requestUri">The Uri the request is sent to.</param>
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstreamasync#system-net-http-httpclient-getstreamasync(system-string-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstreamasync#system-net-http-httpclient-getstreamasync(system-string-system-threading-cancellationtoken)
     public static async Task<Stream> GetStreamAsync(
         this HttpClient target,
         string requestUri,
@@ -62,7 +62,7 @@ static partial class Polyfill
     /// <param name="requestUri">The Uri the request is sent to.</param>
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstreamasync#system-net-http-httpclient-getstreamasync(system-uri-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstreamasync#system-net-http-httpclient-getstreamasync(system-uri-system-threading-cancellationtoken)
     public static Task<Stream> GetStreamAsync(
         this HttpClient target,
         Uri requestUri,
@@ -79,7 +79,7 @@ static partial class Polyfill
     /// <param name="requestUri">The Uri the request is sent to.</param>
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getbytearrayasync#system-net-http-httpclient-getbytearrayasync(system-string-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getbytearrayasync#system-net-http-httpclient-getbytearrayasync(system-string-system-threading-cancellationtoken)
     public static async Task<byte[]> GetByteArrayAsync(
         this HttpClient target,
         string requestUri,
@@ -118,7 +118,7 @@ static partial class Polyfill
     /// <param name="requestUri">The Uri the request is sent to.</param>
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getbytearrayasync#system-net-http-httpclient-getbytearrayasync(system-uri-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getbytearrayasync#system-net-http-httpclient-getbytearrayasync(system-uri-system-threading-cancellationtoken)
     public static Task<byte[]> GetByteArrayAsync(
         this HttpClient target,
         Uri requestUri,
@@ -135,7 +135,7 @@ static partial class Polyfill
     /// <param name="requestUri">The Uri the request is sent to.</param>
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstringasync#system-net-http-httpclient-getstringasync(system-string-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstringasync#system-net-http-httpclient-getstringasync(system-string-system-threading-cancellationtoken)
     public static async Task<string> GetStringAsync(
         this HttpClient target,
         string requestUri,
@@ -174,7 +174,7 @@ static partial class Polyfill
     /// <param name="requestUri">The Uri the request is sent to.</param>
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstringasync#system-net-http-httpclient-getstringasync(system-uri-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstringasync#system-net-http-httpclient-getstringasync(system-uri-system-threading-cancellationtoken)
     public static Task<string> GetStringAsync(
         this HttpClient target,
         Uri requestUri,

--- a/src/Polyfill/Polyfill_HttpContent.cs
+++ b/src/Polyfill/Polyfill_HttpContent.cs
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasstreamasync#system-net-http-httpcontent-readasstreamasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasstreamasync#system-net-http-httpcontent-readasstreamasync(system-threading-cancellationtoken)
     public static Task<Stream> ReadAsStreamAsync(
         this HttpContent target,
         CancellationToken cancellationToken = default)
@@ -45,7 +45,7 @@ static partial class Polyfill
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasbytearrayasync#system-net-http-httpcontent-readasbytearrayasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasbytearrayasync#system-net-http-httpcontent-readasbytearrayasync(system-threading-cancellationtoken)
     public static Task<byte[]> ReadAsByteArrayAsync(
         this HttpContent target,
         CancellationToken cancellationToken = default)
@@ -66,7 +66,7 @@ static partial class Polyfill
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasstringasync#system-net-http-httpcontent-readasstringasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasstringasync#system-net-http-httpcontent-readasstringasync(system-threading-cancellationtoken)
     public static Task<string> ReadAsStringAsync(
         this HttpContent target,
         CancellationToken cancellationToken = default)

--- a/src/Polyfill/Polyfill_IEnumerable_AggregateBy.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_AggregateBy.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
     /// <summary>
     /// https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview#linq
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.aggregateby#system-linq-enumerable-aggregateby-3(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-func((-1-2))-system-func((-2-0-2))-system-collections-generic-iequalitycomparer((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.aggregateby#system-linq-enumerable-aggregateby-3(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-func((-1-2))-system-func((-2-0-2))-system-collections-generic-iequalitycomparer((-1)))
     public static IEnumerable<KeyValuePair<TKey, TAccumulate>> AggregateBy<TSource, TKey, TAccumulate>(
         this IEnumerable<TSource> source,
         Func<TSource, TKey> keySelector,
@@ -34,7 +34,7 @@ static partial class Polyfill
     /// <summary>
     /// https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview#linq
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.aggregateby#system-linq-enumerable-aggregateby-3(system-collections-generic-ienumerable((-0))-system-func((-0-1))-2-system-func((-2-0-2))-system-collections-generic-iequalitycomparer((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.aggregateby#system-linq-enumerable-aggregateby-3(system-collections-generic-ienumerable((-0))-system-func((-0-1))-2-system-func((-2-0-2))-system-collections-generic-iequalitycomparer((-1)))
     public static IEnumerable<KeyValuePair<TKey, TAccumulate>> AggregateBy<TSource, TKey, TAccumulate>(
         this IEnumerable<TSource> source,
         Func<TSource, TKey> keySelector,

--- a/src/Polyfill/Polyfill_IEnumerable_Append.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Append.cs
@@ -19,7 +19,7 @@ static partial class Polyfill
     /// <param name="element">The value to append to <paramref name="target" />.</param>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <returns>A new sequence that ends with element.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.append")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.append
     public static IEnumerable<TSource> Append<TSource>(
         this IEnumerable<TSource> target,
         TSource element)

--- a/src/Polyfill/Polyfill_IEnumerable_Chunk.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Chunk.cs
@@ -26,7 +26,7 @@ static partial class Polyfill
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk
     public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int size)
     {
         if (source is null)

--- a/src/Polyfill/Polyfill_IEnumerable_CountBy.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_CountBy.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
     /// <summary>
     /// https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview#linq
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.countby")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.countby
     public static IEnumerable<KeyValuePair<TKey, int>> CountBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer = null)
         where TKey : notnull
     {

--- a/src/Polyfill/Polyfill_IEnumerable_DistinctBy.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_DistinctBy.cs
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// <para>This method is implemented by using deferred execution. The immediate return value is an object that stores all the information that is required to perform the action. The query represented by this method is not executed until the object is enumerated either by calling its `GetEnumerator` method directly or by using `foreach` in Visual C# or `For Each` in Visual Basic.</para>
     /// <para>The <see cref="DistinctBy{TSource, TKey}(IEnumerable{TSource}, Func{TSource, TKey})" /> method returns an unordered sequence that contains no duplicate values. The default equality comparer, <see cref="EqualityComparer{T}.Default" />, is used to compare values.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.distinctby#system-linq-enumerable-distinctby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.distinctby#system-linq-enumerable-distinctby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1)))
     public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
         DistinctBy(source, keySelector, null);
 
@@ -39,7 +39,7 @@ static partial class Polyfill
     /// <para>This method is implemented by using deferred execution. The immediate return value is an object that stores all the information that is required to perform the action. The query represented by this method is not executed until the object is enumerated either by calling its `GetEnumerator` method directly or by using `foreach` in Visual C# or `For Each` in Visual Basic.</para>
     /// <para>The <see cref="DistinctBy{TSource, TKey}(IEnumerable{TSource}, Func{TSource, TKey}, IEqualityComparer{TKey}?)" /> method returns an unordered sequence that contains no duplicate values. If <paramref name="comparer" /> is <see langword="null" />, the default equality comparer, <see cref="EqualityComparer{T}.Default" />, is used to compare values.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.distinctby#system-linq-enumerable-distinctby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-collections-generic-iequalitycomparer((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.distinctby#system-linq-enumerable-distinctby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-collections-generic-iequalitycomparer((-1)))
     public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
     {
         using IEnumerator<TSource> enumerator = source.GetEnumerator();

--- a/src/Polyfill/Polyfill_IEnumerable_ElementAt.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_ElementAt.cs
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// <para>If the type of <paramref name="source" /> implements <see cref="IList{T}" />, that implementation is used to obtain the element at the specified index. Otherwise, this method obtains the specified element.</para>
     /// <para>This method throws an exception if <paramref name="index" /> is out of range. To instead return a default value when the specified index is out of range, use the <see cref="O:Enumerable.ElementAtOrDefault" /> method.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.elementat#system-linq-enumerable-elementat-1(system-collections-generic-ienumerable((-0))-system-index)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.elementat#system-linq-enumerable-elementat-1(system-collections-generic-ienumerable((-0))-system-index)
     public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, Index index)
     {
         if (!index.IsFromEnd)
@@ -86,7 +86,7 @@ static partial class Polyfill
     /// <para>If the type of <paramref name="source" /> implements <see cref="IList{T}" />, that implementation is used to obtain the element at the specified index. Otherwise, this method obtains the specified element.</para>
     /// <para>The default value for reference and nullable types is <see langword="null" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.elementatordefault#system-linq-enumerable-elementatordefault-1(system-collections-generic-ienumerable((-0))-system-index)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.elementatordefault#system-linq-enumerable-elementatordefault-1(system-collections-generic-ienumerable((-0))-system-index)
     public static TSource? ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, Index index)
     {
         if (!index.IsFromEnd)

--- a/src/Polyfill/Polyfill_IEnumerable_Except.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Except.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0)))
     public static IEnumerable<TSource> Except<TSource>(
         this IEnumerable<TSource> target,
         TSource item) =>
@@ -31,7 +31,7 @@ static partial class Polyfill
     // /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
     // /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     // /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
-    // [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0)))")]
+    // //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0)))
     // public static IEnumerable<TSource> Except<TSource>(
     //     this IEnumerable<TSource> target,
     //     params TSource[] items) =>
@@ -45,7 +45,7 @@ static partial class Polyfill
     /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare values.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))
     public static IEnumerable<TSource> Except<TSource>(
         this IEnumerable<TSource> target,
         TSource item,
@@ -69,7 +69,7 @@ static partial class Polyfill
     /// <param name="item">An <see cref="TSource"/> that is elements equal it will cause those elements to be removed from the returned sequence.</param>
     /// <typeparam name="TSource">The type of the elements of <paramref name="target" />.</typeparam>
     /// <returns>A sequence that contains the items of <paramref name="target"/> but excluding <paramref name="item"/>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.except#system-linq-enumerable-except-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))
     public static IEnumerable<TSource> Except<TSource>(
         this IEnumerable<TSource> target,
         IEqualityComparer<TSource> comparer,
@@ -87,7 +87,7 @@ static partial class Polyfill
     /// <param name="second">An <see cref="IEnumerable{TKey}" /> whose keys that also occur in the first sequence will cause those elements to be removed from the returned sequence.</param>
     /// <param name="keySelector">A function to extract the key for each element.</param>
     /// <returns>A sequence that contains the set difference of the elements of two sequences.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.exceptby#system-linq-enumerable-exceptby-2(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1))-system-func((-0-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.exceptby#system-linq-enumerable-exceptby-2(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1))-system-func((-0-1)))
     public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector) =>
         ExceptBy(first, second, keySelector, null);
 
@@ -101,7 +101,7 @@ static partial class Polyfill
     /// <param name="keySelector">A function to extract the key for each element.</param>
     /// <param name="comparer">The <see cref="IEqualityComparer{TKey}" /> to compare values.</param>
     /// <returns>A sequence that contains the set difference of the elements of two sequences.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.exceptby#system-linq-enumerable-exceptby-2(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1))-system-func((-0-1))-system-collections-generic-iequalitycomparer((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.exceptby#system-linq-enumerable-exceptby-2(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1))-system-func((-0-1))-system-collections-generic-iequalitycomparer((-1)))
     public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer) =>
         ExceptByIterator(first, second, keySelector, comparer);
 

--- a/src/Polyfill/Polyfill_IEnumerable_FirstOrDefault.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_FirstOrDefault.cs
@@ -18,7 +18,7 @@ static partial class Polyfill
     /// <param name="defaultValue">The default value to return if the sequence is empty.</param>
     /// <returns><paramref name="defaultValue" /> if <paramref name="source" /> is empty or if no element passes the test specified by <paramref name="predicate" />; otherwise, the first element in <paramref name="source" /> that passes the test specified by <paramref name="predicate" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="predicate" /> is <see langword="null" />.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.firstordefault#system-linq-enumerable-firstordefault-1(system-collections-generic-ienumerable((-0))-system-func((-0-system-boolean))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.firstordefault#system-linq-enumerable-firstordefault-1(system-collections-generic-ienumerable((-0))-system-func((-0-system-boolean))-0)
     public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
     {
         TSource? first = source.TryGetFirst(predicate, out bool found);
@@ -31,7 +31,7 @@ static partial class Polyfill
     /// <param name="defaultValue">The default value to return if the sequence is empty.</param>
     /// <returns><paramref name="defaultValue" /> if <paramref name="source" /> is empty; otherwise, the first element in <paramref name="source" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.firstordefault#system-linq-enumerable-firstordefault-1(system-collections-generic-ienumerable((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.firstordefault#system-linq-enumerable-firstordefault-1(system-collections-generic-ienumerable((-0))-0)
     public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
     {
         TSource? first = source.TryGetFirst(out bool found);

--- a/src/Polyfill/Polyfill_IEnumerable_Index.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Index.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
     /// <summary>
     /// https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview#linq
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.index#system-linq-enumerable-index-1(system-collections-generic-ienumerable((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.index#system-linq-enumerable-index-1(system-collections-generic-ienumerable((-0)))
     public static IEnumerable<(int Index, TSource Item)> Index<TSource>(this IEnumerable<TSource> source)
     {
         int index = 0;

--- a/src/Polyfill/Polyfill_IEnumerable_LastOrDefault.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_LastOrDefault.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// <param name="defaultValue">The default value to return if the sequence is empty.</param>
     /// <returns><paramref name="defaultValue" /> if the source sequence is empty; otherwise, the last element in the <see cref="IEnumerable{T}" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.lastordefault#system-linq-enumerable-lastordefault-1(system-collections-generic-ienumerable((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.lastordefault#system-linq-enumerable-lastordefault-1(system-collections-generic-ienumerable((-0))-0)
     public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
     {
         TSource? last = source.TryGetLast(out bool found);
@@ -31,7 +31,7 @@ static partial class Polyfill
     /// <param name="defaultValue">The default value to return if the sequence is empty.</param>
     /// <returns><paramref name="defaultValue" /> if the sequence is empty or if no elements pass the test in the predicate function; otherwise, the last element that passes the test in the predicate function.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="predicate" /> is <see langword="null" />.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.lastordefault#system-linq-enumerable-lastordefault-1(system-collections-generic-ienumerable((-0))-system-func((-0-system-boolean))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.lastordefault#system-linq-enumerable-lastordefault-1(system-collections-generic-ienumerable((-0))-system-func((-0-system-boolean))-0)
     public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
     {
         TSource? last = source.TryGetLast(predicate, out bool found);

--- a/src/Polyfill/Polyfill_IEnumerable_Max.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Max.cs
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// <para>If <typeparamref name="TSource" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
     /// <para>In Visual Basic query expression syntax, an `Aggregate Into Max()` clause translates to an invocation of <see cref="O:Enumerable.Max" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.max?view=net-8.0#system-linq-enumerable-max-1(system-collections-generic-ienumerable((-0))-system-collections-generic-icomparer((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.max?view=net-8.0#system-linq-enumerable-max-1(system-collections-generic-ienumerable((-0))-system-collections-generic-icomparer((-0)))
     public static TSource? Max<TSource>(
         this IEnumerable<TSource> source,
         IComparer<TSource>? comparer) =>

--- a/src/Polyfill/Polyfill_IEnumerable_MaxBy.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_MaxBy.cs
@@ -25,7 +25,7 @@ static partial class Polyfill
     /// <remarks>
     /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1)))
     public static TSource? MaxBy<TSource, TKey>(
         this IEnumerable<TSource> source,
         Func<TSource, TKey> keySelector) =>
@@ -43,7 +43,7 @@ static partial class Polyfill
     /// <remarks>
     /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-collections-generic-icomparer((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby#system-linq-enumerable-maxby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-collections-generic-icomparer((-1)))
     public static TSource? MaxBy<TSource, TKey>(
         this IEnumerable<TSource> source,
         Func<TSource, TKey> keySelector,

--- a/src/Polyfill/Polyfill_IEnumerable_Min.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Min.cs
@@ -25,7 +25,7 @@ static partial class Polyfill
     /// <para>If <typeparamref name="TSource" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
     /// <para>In Visual Basic query expression syntax, an `Aggregate Into Min()` clause translates to an invocation of <see cref="O:Enumerable.Min" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.min?view=net-8.0#system-linq-enumerable-min-1(system-collections-generic-ienumerable((-0))-system-collections-generic-icomparer((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.min?view=net-8.0#system-linq-enumerable-min-1(system-collections-generic-ienumerable((-0))-system-collections-generic-icomparer((-0)))
     public static TSource? Min<TSource>(
         this IEnumerable<TSource> source,
         IComparer<TSource>? comparer) =>

--- a/src/Polyfill/Polyfill_IEnumerable_MinBy.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_MinBy.cs
@@ -26,7 +26,7 @@ static partial class Polyfill
     /// <remarks>
     /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.minby#system-linq-enumerable-minby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.minby#system-linq-enumerable-minby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1)))
     public static TSource? MinBy<TSource, TKey>(
         this IEnumerable<TSource> source,
         Func<TSource, TKey> keySelector) =>
@@ -44,7 +44,7 @@ static partial class Polyfill
     /// <remarks>
     /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.minby#system-linq-enumerable-minby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-collections-generic-icomparer((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.minby#system-linq-enumerable-minby-2(system-collections-generic-ienumerable((-0))-system-func((-0-1))-system-collections-generic-icomparer((-1)))
     public static TSource? MinBy<TSource, TKey>(
         this IEnumerable<TSource> source,
         Func<TSource, TKey> keySelector,

--- a/src/Polyfill/Polyfill_IEnumerable_SingleOrDefault.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_SingleOrDefault.cs
@@ -19,7 +19,7 @@ static partial class Polyfill
     /// <returns>The single element of the input sequence that satisfies the condition, or <paramref name="defaultValue" /> if no such element is found.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="predicate" /> is <see langword="null" />.</exception>
     /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate" />.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.singleordefault#system-linq-enumerable-singleordefault-1(system-collections-generic-ienumerable((-0))-system-func((-0-system-boolean))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.singleordefault#system-linq-enumerable-singleordefault-1(system-collections-generic-ienumerable((-0))-system-func((-0-system-boolean))-0)
     public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
     {
         var single = source.TryGetSingle(predicate, out bool found);
@@ -59,7 +59,7 @@ static partial class Polyfill
     /// <returns>The single element of the input sequence, or <paramref name="defaultValue" /> if the sequence contains no elements.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.singleordefault#system-linq-enumerable-singleordefault-1(system-collections-generic-ienumerable((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.singleordefault#system-linq-enumerable-singleordefault-1(system-collections-generic-ienumerable((-0))-0)
     public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
     {
         var single = source.TryGetSingle(out bool found);

--- a/src/Polyfill/Polyfill_IEnumerable_SkipLast.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_SkipLast.cs
@@ -21,7 +21,7 @@ static partial class Polyfill
     /// <typeparam name="TSource">The type of the elements in the enumerable collection.</typeparam>
     /// <returns>A new enumerable collection that contains the elements from source minus count elements from the end
     /// of the collection.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.skiplast")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.skiplast
     public static IEnumerable<TSource> SkipLast<TSource>(
         this IEnumerable<TSource> target,
         int count) =>

--- a/src/Polyfill/Polyfill_IEnumerable_Take.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Take.cs
@@ -165,7 +165,7 @@ static partial class Polyfill
     /// <para>This method is implemented by using deferred execution. The immediate return value is an object that stores all the information that is required to perform the action. The query represented by this method is not executed until the object is enumerated either by calling its `GetEnumerator` method directly or by using `foreach` in Visual C# or `For Each` in Visual Basic.</para>
     /// <para><see cref="O:Enumerable.Take" /> enumerates <paramref name="source" /> and yields elements whose indices belong to the specified <paramref name="range"/>.</para>
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.take?view=net-8.0#system-linq-enumerable-take-1(system-collections-generic-ienumerable((-0))-system-range)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.take?view=net-8.0#system-linq-enumerable-take-1(system-collections-generic-ienumerable((-0))-system-range)
     public static IEnumerable<TSource> Take<TSource>(
         this IEnumerable<TSource> target,
         Range range)

--- a/src/Polyfill/Polyfill_IEnumerable_TakeLast.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_TakeLast.cs
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// <param name="count">The number of elements to take from the end of the collection.</param>
     /// <typeparam name="TSource">The type of the elements in the enumerable collection.</typeparam>
     /// <returns>A new enumerable collection that contains the last count elements from source.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast
     public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)
     {
         if (count <= 0 || IsEmptyArray(source))

--- a/src/Polyfill/Polyfill_IEnumerable_ToHashSet.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_ToHashSet.cs
@@ -19,7 +19,7 @@ static partial class Polyfill
     /// <param name="comparer">An IEqualityComparer<T> to compare keys.</param>
     /// <typeparam name="TSource">The type of the elements of source.</typeparam>
     /// <returns>A HashSet<T> that contains values of type TSource selected from the input sequence.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tohashset#system-linq-enumerable-tohashset-1(system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tohashset#system-linq-enumerable-tohashset-1(system-collections-generic-ienumerable((-0))-system-collections-generic-iequalitycomparer((-0)))
     public static HashSet<TSource> ToHashSet<TSource>(
         this IEnumerable<TSource> target,
         IEqualityComparer<TSource>? comparer = null) =>

--- a/src/Polyfill/Polyfill_IEnumerable_TryGetNonEnumeratedCount.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_TryGetNonEnumeratedCount.cs
@@ -32,7 +32,7 @@ static partial class Polyfill
     ///   The method is typically a constant-time operation, but ultimately this depends on the complexity
     ///   characteristics of the underlying collection implementation.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.trygetnonenumeratedcount")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.trygetnonenumeratedcount
     public static bool TryGetNonEnumeratedCount<TSource>(this IEnumerable<TSource> target, out int count)
     {
         if (target is ICollection<TSource> genericCollection)

--- a/src/Polyfill/Polyfill_IEnumerable_Zip.cs
+++ b/src/Polyfill/Polyfill_IEnumerable_Zip.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
     /// <param name="second">The second sequence to merge.</param>
     /// <param name="third">The third sequence to merge.</param>
     /// <returns>A sequence of tuples with elements taken from the first, second, and third sequences, in that order.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.zip#system-linq-enumerable-zip-3(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1))-system-collections-generic-ienumerable((-2)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.zip#system-linq-enumerable-zip-3(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1))-system-collections-generic-ienumerable((-2)))
     public static IEnumerable<(TFirst First, TSecond Second, TThird Third)> Zip<TFirst, TSecond, TThird>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, IEnumerable<TThird> third)
     {
         using (IEnumerator<TFirst> e1 = first.GetEnumerator())
@@ -47,7 +47,7 @@ static partial class Polyfill
     /// <param name="first">The first sequence to merge.</param>
     /// <param name="second">The second sequence to merge.</param>
     /// <returns>A sequence of tuples with elements taken from the first, and second sequences, in that order.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.zip#system-linq-enumerable-zip-2(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.zip#system-linq-enumerable-zip-2(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-1)))
     public static IEnumerable<(TFirst First, TSecond Second)> Zip<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second)
     {
         using (IEnumerator<TFirst> e1 = first.GetEnumerator())

--- a/src/Polyfill/Polyfill_IReadOnlyDictionary.cs
+++ b/src/Polyfill/Polyfill_IReadOnlyDictionary.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
     /// A TValue instance. When the method is successful, the returned object is the value associated with
     /// the specified key. When the method fails, it returns the default value for TValue.
     /// </returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.getvalueordefault")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.getvalueordefault
     public static TValue? GetValueOrDefault<TKey, TValue>(
         this IReadOnlyDictionary<TKey, TValue> target,
         TKey key)
@@ -48,7 +48,7 @@ static partial class Polyfill
     /// A TValue instance. When the method is successful, the returned object is the value associated with
     /// the specified key. When the method fails, it returns the default value for TValue.
     /// </returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.getvalueordefault#system-collections-generic-collectionextensions-getvalueordefault-2(system-collections-generic-ireadonlydictionary((-0-1))-0-1)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.getvalueordefault#system-collections-generic-collectionextensions-getvalueordefault-2(system-collections-generic-ireadonlydictionary((-0-1))-0-1)
     public static TValue GetValueOrDefault<TKey, TValue>(
         this IReadOnlyDictionary<TKey, TValue> target,
         TKey key,

--- a/src/Polyfill/Polyfill_KeyValuePair.cs
+++ b/src/Polyfill/Polyfill_KeyValuePair.cs
@@ -16,7 +16,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="key">The key of the current <see cref="KeyValuePair{TKey,TValue}"/>.</param>
     /// <param name="value">The value of the current <see cref="KeyValuePair{TKey,TValue}"/>.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.keyvaluepair-2.deconstruct")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.keyvaluepair-2.deconstruct
     public static void Deconstruct<TKey, TValue>(
         this KeyValuePair<TKey, TValue> target,
         out TKey key,

--- a/src/Polyfill/Polyfill_List.cs
+++ b/src/Polyfill/Polyfill_List.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
 
     /// <summary>Returns a read-only <see cref="ReadOnlyCollection{T}" /> wrapper for the current collection.</summary>
     /// <returns>An object that acts as a read-only wrapper around the current <see cref="IList{T}" />.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.asreadonly#system-collections-generic-collectionextensions-asreadonly-1(system-collections-generic-ilist((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.asreadonly#system-collections-generic-collectionextensions-asreadonly-1(system-collections-generic-ilist((-0)))
     public static ReadOnlyCollection<T> AsReadOnly<T>(this IList<T> target) =>
         new(target);
 #endif
@@ -25,7 +25,7 @@ static partial class Polyfill
     /// <param name="list">The list to which the elements should be added.</param>
     /// <param name="source">The span whose elements should be added to the end of the <see cref="List{T}"/>.</param>
     /// <exception cref="ArgumentNullException">The <paramref name="list"/> is null.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.addrange")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.addrange
     public static void AddRange<T>(this List<T> target, ReadOnlySpan<T> source)
     {
         foreach (var item in source)
@@ -41,7 +41,7 @@ static partial class Polyfill
     /// <param name="source">The span whose elements should be added to the <see cref="List{T}"/>.</param>
     /// <exception cref="ArgumentNullException">The <paramref name="list"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than 0 or greater than <paramref name="list"/>'s <see cref="List{T}.Count"/>.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.insertrange")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.insertrange
     public static void InsertRange<T>(this List<T> target, int index, ReadOnlySpan<T> source)
     {
         for (var i = 0; i < source.Length; i++)
@@ -57,7 +57,7 @@ static partial class Polyfill
     /// <param name="destination">The span that is the destination of the elements copied from <paramref name="list"/>.</param>
     /// <exception cref="ArgumentNullException">The <paramref name="list"/> is null.</exception>
     /// <exception cref="ArgumentException">The number of elements in the source <see cref="List{T}"/> is greater than the number of elements that the destination span can contain.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.copyto")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.copyto
     public static void CopyTo<T>(this List<T> target, Span<T> destination)
     {
         for (var index = 0; index < target.Count; index++)

--- a/src/Polyfill/Polyfill_Memory.cs
+++ b/src/Polyfill/Polyfill_Memory.cs
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// for <see cref="string.ReplaceLineEndings"/> for more information on how newline
     /// sequences are detected.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.enumeratelines#system-memoryextensions-enumeratelines(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.enumeratelines#system-memoryextensions-enumeratelines(system-readonlyspan((system-char)))
     public static SpanLineEnumerator EnumerateLines(this ReadOnlySpan<char> target) =>
         new(target);
 
@@ -36,7 +36,7 @@ static partial class Polyfill
     /// for <see cref="string.ReplaceLineEndings"/> for more information on how newline
     /// sequences are detected.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.enumeratelines#system-memoryextensions-enumeratelines(system-span((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.enumeratelines#system-memoryextensions-enumeratelines(system-span((system-char)))
     public static SpanLineEnumerator EnumerateLines(this Span<char> target) =>
         new(target);
 
@@ -48,7 +48,7 @@ static partial class Polyfill
     /// Removes all leading white-space characters from the span.
     /// </summary>
     /// <param name="span">The source span from which the characters are removed.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.trimstart#system-memoryextensions-trimstart(system-span((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.trimstart#system-memoryextensions-trimstart(system-span((system-char)))
     public static Span<char> TrimStart(this Span<char> target)
         => target.Slice(ClampStart(target));
 
@@ -56,7 +56,7 @@ static partial class Polyfill
     /// Removes all trailing white-space characters from the span.
     /// </summary>
     /// <param name="span">The source span from which the characters are removed.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.trimend#system-memoryextensions-trimend(system-span((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.trimend#system-memoryextensions-trimend(system-span((system-char)))
     public static Span<char> TrimEnd(this Span<char> target)
         => target.Slice(0, ClampEnd(target, 0));
 
@@ -104,7 +104,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="value">The value to search for.</param>
     /// <returns><c>true</c> if found, <c>false</c> otherwise.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.contains#system-memoryextensions-contains-1(system-readonlyspan((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.contains#system-memoryextensions-contains-1(system-readonlyspan((-0))-0)
     public static bool Contains<T>(
         this ReadOnlySpan<T> target,
         T value)
@@ -126,7 +126,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="value">The value to search for.</param>
     /// <returns><c>true</c> if found, <c>false</c> otherwise.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.contains#system-memoryextensions-contains-1(system-span((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.contains#system-memoryextensions-contains-1(system-span((-0))-0)
     public static bool Contains<T>(
         this Span<T> target,
         T value)
@@ -149,7 +149,7 @@ static partial class Polyfill
     /// <param name="target">The first sequence to compare.</param>
     /// <param name="other">The second sequence to compare.</param>
     /// <returns><c>true</c> if the two sequences are equal; otherwise, <c>false</c>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequenceequal#system-memoryextensions-sequenceequal-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequenceequal#system-memoryextensions-sequenceequal-1(system-readonlyspan((-0))-system-readonlyspan((-0)))
     public static bool SequenceEqual(
         this ReadOnlySpan<char> target,
         string other) =>
@@ -161,7 +161,7 @@ static partial class Polyfill
     /// <param name="target">The first sequence to compare.</param>
     /// <param name="other">The second sequence to compare.</param>
     /// <returns><c>true</c> if the two sequences are equal; otherwise, <c>false</c>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequenceequal#system-memoryextensions-sequenceequal-1(system-span((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequenceequal#system-memoryextensions-sequenceequal-1(system-span((-0))-system-readonlyspan((-0)))
     public static bool SequenceEqual(
         this Span<char> target,
         string other) =>

--- a/src/Polyfill/Polyfill_Memory_EndsWith.cs
+++ b/src/Polyfill/Polyfill_Memory_EndsWith.cs
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="target">The span to search.</param>
     /// <param name="value">The value to compare.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-0)
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool EndsWith<T>(this ReadOnlySpan<T> target, T value)
         where T : IEquatable<T>? =>
@@ -40,7 +40,7 @@ static partial class Polyfill
     /// <param name="other">The sequence to compare to the end of the source span.</param>
     /// <param name="comparison">An enumeration value that determines how span and value are compared.</param>
     /// <returns><c>true</c> if value matches the end of span; otherwise, <c>false</c>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-system-readonlyspan((-0)))
     public static bool EndsWith(
         this ReadOnlySpan<char> target,
         string other,
@@ -53,7 +53,7 @@ static partial class Polyfill
     /// <param name="target">The source span.</param>
     /// <param name="other">The sequence to compare to the end of the source span.</param>
     /// <returns><c>true</c> if value matches the end of span; otherwise, <c>false</c>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-span((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-span((-0))-system-readonlyspan((-0)))
     public static bool EndsWith(
         this Span<char> target,
         string other) =>

--- a/src/Polyfill/Polyfill_Memory_SpanSplit.cs
+++ b/src/Polyfill/Polyfill_Memory_SpanSplit.cs
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// <param name="source">The source span to be enumerated.</param>
     /// <param name="separator">The separator character to be used to split the provided span.</param>
     /// <returns>Returns a <see cref="SpanSplitEnumerator{T}"/>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.split#system-memoryextensions-split-1(system-readonlyspan((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.split#system-memoryextensions-split-1(system-readonlyspan((-0))-0)
     public static SpanSplitEnumerator<T> Split<T>(this ReadOnlySpan<T> source, T separator)
         where T : IEquatable<T> =>
         new SpanSplitEnumerator<T>(source, separator);
@@ -36,7 +36,7 @@ static partial class Polyfill
     /// <param name="source">The source span to be enumerated.</param>
     /// <param name="separator">The separator span to be used to split the provided span.</param>
     /// <returns>Returns a <see cref="SpanSplitEnumerator{T}"/>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.split#system-memoryextensions-split-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.split#system-memoryextensions-split-1(system-readonlyspan((-0))-system-readonlyspan((-0)))
     public static SpanSplitEnumerator<T> Split<T>(this ReadOnlySpan<T> source, ReadOnlySpan<T> separator)
         where T : IEquatable<T> =>
         new SpanSplitEnumerator<T>(source, separator, treatAsSingleSeparator: true);
@@ -58,7 +58,7 @@ static partial class Polyfill
     /// or when <see cref="SplitAny(ReadOnlySpan{char}, Span{Range}, ReadOnlySpan{char}, StringSplitOptions)"/>
     /// is used with an empty separator span.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.splitany#system-memoryextensions-splitany-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.splitany#system-memoryextensions-splitany-1(system-readonlyspan((-0))-system-readonlyspan((-0)))
     public static SpanSplitEnumerator<T> SplitAny<T>(this ReadOnlySpan<T> source, [UnscopedRef] params ReadOnlySpan<T> separators)
         where T : IEquatable<T> =>
         new SpanSplitEnumerator<T>(source, separators);
@@ -81,7 +81,7 @@ static partial class Polyfill
     /// whereas <see cref="SplitAny{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/> will use all Unicode whitespace characters as separators if <paramref name="separators"/> is
     /// empty and <typeparamref name="T"/> is <see cref="char"/>.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.splitany#system-memoryextensions-splitany-1(system-readonlyspan((-0))-system-buffers-searchvalues((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.splitany#system-memoryextensions-splitany-1(system-readonlyspan((-0))-system-buffers-searchvalues((-0)))
     public static SpanSplitEnumerator<T> SplitAny<T>(this ReadOnlySpan<T> source, SearchValues<T> separators)
         where T : IEquatable<T> =>
         new SpanSplitEnumerator<T>(source, separators);

--- a/src/Polyfill/Polyfill_Memory_SpanSplitEnumerator.cs
+++ b/src/Polyfill/Polyfill_Memory_SpanSplitEnumerator.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// Enables enumerating each split within a <see cref="ReadOnlySpan{T}"/> that has been divided using one or more separators.
     /// </summary>
     //https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.spansplitenumerator-1")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.spansplitenumerator-1")]
     public ref struct SpanSplitEnumerator<T>
         where T : IEquatable<T>
     {

--- a/src/Polyfill/Polyfill_Memory_StartsWith.cs
+++ b/src/Polyfill/Polyfill_Memory_StartsWith.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="target">The span to search.</param>
     /// <param name="value">The value to compare.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-0)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.endswith#system-memoryextensions-endswith-1(system-readonlyspan((-0))-0)
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool StartsWith<T>(this ReadOnlySpan<T> target, T value)
         where T : IEquatable<T>? =>
@@ -39,7 +39,7 @@ static partial class Polyfill
     /// <param name="other">The sequence to compare to the beginning of the source span.</param>
     /// <param name="comparison">An enumeration value that determines how span and value are compared.</param>
     /// <returns><c>true</c> if value matches the beginning of span; otherwise, <c>false</c>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.startswith#system-memoryextensions-startswith-1(system-readonlyspan((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.startswith#system-memoryextensions-startswith-1(system-readonlyspan((-0))-system-readonlyspan((-0)))
     public static bool StartsWith(
         this ReadOnlySpan<char> target,
         string other,
@@ -52,7 +52,7 @@ static partial class Polyfill
     /// <param name="target">The source span.</param>
     /// <param name="other">The sequence to compare to the beginning of the source span.</param>
     /// <returns><c>true</c> if value matches the beginning of span; otherwise, <c>false</c>.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.startswith#system-memoryextensions-startswith-1(system-span((-0))-system-readonlyspan((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.startswith#system-memoryextensions-startswith-1(system-span((-0))-system-readonlyspan((-0)))
     public static bool StartsWith(
         this Span<char> target,
         string other) =>

--- a/src/Polyfill/Polyfill_MicroNanosecond.cs
+++ b/src/Polyfill/Polyfill_MicroNanosecond.cs
@@ -13,42 +13,42 @@ static partial class Polyfill
     /// <summary>
     /// Gets the nanosecond component of the time represented by the current <see cref="TimeSpan"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.timespan.nanoseconds")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.timespan.nanoseconds
     public static int Nanoseconds(this TimeSpan target) =>
         target.Nanoseconds;
 
     /// <summary>
     /// Gets the nanosecond component of the time represented by the current <see cref="DateTime"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.nanosecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.nanosecond
     public static int Nanosecond(this DateTime target) =>
         target.Nanosecond;
 
     /// <summary>
     /// Gets the nanosecond component of the time represented by the current <see cref="DateTimeOffset"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.nanosecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.nanosecond
     public static int Nanosecond(this DateTimeOffset target) =>
         target.Nanosecond;
 
     /// <summary>
     /// Gets the microsecond component of the time represented by the current <see cref="TimeSpan"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.timespan.microsecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.timespan.microsecond
     public static int Microseconds(this TimeSpan target) =>
         target.Microseconds;
 
     /// <summary>
     /// Gets the microsecond component of the time represented by the current <see cref="DateTime"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.microsecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.microsecond
     public static int Microsecond(this DateTime target) =>
         target.Microsecond;
 
     /// <summary>
     /// Gets the microsecond component of the time represented by the current <see cref="DateTimeOffset"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.microsecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.microsecond
     public static int Microsecond(this DateTimeOffset target) =>
         target.Microsecond;
 
@@ -59,42 +59,42 @@ static partial class Polyfill
     /// <summary>
     /// Gets the nanosecond component of the time represented by the current <see cref="TimeSpan"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.timespan.nanoseconds")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.timespan.nanoseconds
     public static int Nanoseconds(this TimeSpan target) =>
         (int) (target.TicksComponent() % TicksPerMicrosecond) * 100;
 
     /// <summary>
     /// Gets the nanosecond component of the time represented by the current <see cref="DateTime"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.nanosecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.nanosecond
     public static int Nanosecond(this DateTime target) =>
         (int) (target.TicksComponent() % TicksPerMicrosecond) * 100;
 
     /// <summary>
     /// Gets the nanosecond component of the time represented by the current <see cref="DateTimeOffset"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.nanosecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.nanosecond
     public static int Nanosecond(this DateTimeOffset target) =>
         (int) (target.TicksComponent() % TicksPerMicrosecond) * 100;
 
     /// <summary>
     /// Gets the microsecond component of the time represented by the current <see cref="TimeSpan"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.timespan.microseconds")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.timespan.microseconds
     public static int Microseconds(this TimeSpan target) =>
         (int) (target.TicksComponent() % TicksPerMicrosecond) * 1000;
 
     /// <summary>
     /// Gets the microsecond component of the time represented by the current <see cref="DateTime"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.microsecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.microsecond
     public static int Microsecond(this DateTime target) =>
         (int) (target.TicksComponent() % TicksPerMicrosecond) * 1000;
 
     /// <summary>
     /// Gets the microsecond component of the time represented by the current <see cref="DateTimeOffset"/> object.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.microsecond")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.microsecond
     public static int Microsecond(this DateTimeOffset target) =>
         (int) (target.TicksComponent() % TicksPerMicrosecond) * 1000;
 

--- a/src/Polyfill/Polyfill_MicroNanosecondAdd.cs
+++ b/src/Polyfill/Polyfill_MicroNanosecondAdd.cs
@@ -13,14 +13,14 @@ static partial class Polyfill
     /// <summary>
     /// Returns a new <see cref="DateTime"/> object that adds a specified number of microseconds to the value of this instance..
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.addmicroseconds")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.addmicroseconds
     public static DateTime AddMicroseconds(this DateTime target, double microseconds) =>
        target.AddMilliseconds(microseconds / 1000);
 
     /// <summary>
     /// Returns a new <see cref="DateTimeOffset"/> object that adds a specified number of microseconds to the value of this instance..
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.addmicroseconds")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.addmicroseconds
     public static DateTimeOffset AddMicroseconds(this DateTimeOffset target, double microseconds) =>
        target.AddMilliseconds(microseconds / 1000);
 

--- a/src/Polyfill/Polyfill_Process.cs
+++ b/src/Polyfill/Polyfill_Process.cs
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// A task that will complete when the process has exited, cancellation has been requested,
     /// or an error occurs.
     /// </returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitasync")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitasync
     public static async Task WaitForExitAsync(this Process target, CancellationToken cancellationToken = default)
     {
         // Because the process has already started by the time this method is called,

--- a/src/Polyfill/Polyfill_Random.cs
+++ b/src/Polyfill/Polyfill_Random.cs
@@ -14,7 +14,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="index">The array to be filled with random numbers.</param>
     /// <remarks>Each element of the span of bytes is set to a random number greater than or equal to 0 and less than or equal to <see cref="byte.MaxValue"/>.</remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.random.nextbytes#system-random-nextbytes(system-span((system-byte)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.random.nextbytes#system-random-nextbytes(system-span((system-byte)))
     public static void NextBytes(
         this Random target,
         Span<byte> buffer)
@@ -36,7 +36,7 @@ static partial class Polyfill
     ///   This method uses <see cref="Next(int, int)" /> to choose values for shuffling.
     ///   This method is an O(n) operation.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.random.nextbytes#system-random-nextbytes(system-span((system-byte)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.random.nextbytes#system-random-nextbytes(system-span((system-byte)))
     public static void Shuffle<T>(
         this Random target,
         T[] values)
@@ -66,7 +66,7 @@ static partial class Polyfill
     ///   This method uses <see cref="Next(int, int)" /> to choose values for shuffling.
     ///   This method is an O(n) operation.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.random.nextbytes#system-random-nextbytes(system-span((system-byte)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.random.nextbytes#system-random-nextbytes(system-span((system-byte)))
     public static void Shuffle<T>(
         this Random target,
         Span<T> values)

--- a/src/Polyfill/Polyfill_SortedList.cs
+++ b/src/Polyfill/Polyfill_SortedList.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// <param name="index">The zero-based index of the key within the entire <see cref="SortedList{TKey, TValue}"/>.</param>
     /// <returns>The key corresponding to the specified index.</returns>
     /// <exception cref="ArgumentOutOfRangeException">The specified index is out of range.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.sortedlist-2.getkeyatindex")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.sortedlist-2.getkeyatindex
     public static TKey GetKeyAtIndex<TKey, TValue>(
         this SortedList<TKey, TValue> target, int index) =>
         target.Keys[index];
@@ -27,7 +27,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="index">The zero-based index of the value within the entire <see cref="SortedList{TKey, TValue}"/>.</param>
     /// <returns>The value corresponding to the specified index.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.sortedlist-2.getvalueatindex")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.sortedlist-2.getvalueatindex
     public static TValue GetValueAtIndex<TKey, TValue>(
         this SortedList<TKey, TValue> target, int index) =>
         target.Values[index];

--- a/src/Polyfill/Polyfill_Stream.cs
+++ b/src/Polyfill/Polyfill_Stream.cs
@@ -30,7 +30,7 @@ static partial class Polyfill
     /// the buffer if that many bytes are not currently available, or it can be 0 (zero) if the end of the stream has
     /// been reached.
     /// </returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.readasync#system-io-stream-readasync(system-memory((system-byte))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.readasync#system-io-stream-readasync(system-memory((system-byte))-system-threading-cancellationtoken)
     public static ValueTask<int> ReadAsync(
         this Stream target,
         Memory<byte> buffer,
@@ -54,7 +54,7 @@ static partial class Polyfill
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.writeasync#system-io-stream-writeasync(system-readonlymemory((system-byte))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.writeasync#system-io-stream-writeasync(system-readonlymemory((system-byte))-system-threading-cancellationtoken)
     public static ValueTask WriteAsync(
         this Stream target,
         ReadOnlyMemory<byte> buffer,
@@ -80,7 +80,7 @@ static partial class Polyfill
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>A task that represents the asynchronous copy operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.copytoasync#system-io-stream-copytoasync(system-io-stream-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.copytoasync#system-io-stream-copytoasync(system-io-stream-system-threading-cancellationtoken)
     public static Task CopyToAsync(
         this Stream target,
         Stream destination,

--- a/src/Polyfill/Polyfill_Stream_DisposeAsync.cs
+++ b/src/Polyfill/Polyfill_Stream_DisposeAsync.cs
@@ -16,7 +16,7 @@ static partial class Polyfill
     /// <summary>
     /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.disposeasync")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.disposeasync
     public static ValueTask DisposeAsync(this Stream target)
     {
         try

--- a/src/Polyfill/Polyfill_String.cs
+++ b/src/Polyfill/Polyfill_String.cs
@@ -15,7 +15,7 @@ static partial class Polyfill
     /// Copies the contents of this string into the destination span.
     /// </summary>
     /// <param name="destination">The span into which to copy this string's contents</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.copyto")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.copyto
     public static void CopyTo(this string target, Span<char> destination) =>
         target.AsSpan().CopyTo(destination);
 
@@ -24,7 +24,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="destination">The span into which to copy this string's contents</param>
     /// <returns>true if the data was copied; false if the destination was too short to fit the contents of the string.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.trycopyto")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.trycopyto
     public static bool TryCopyTo(this string target, Span<char> destination) =>
         target.AsSpan().TryCopyTo(destination);
 #endif
@@ -36,7 +36,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
     /// <returns>A 32-bit signed integer hash code.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.gethashcode#system-string-gethashcode(system-stringcomparison)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.gethashcode#system-string-gethashcode(system-stringcomparison)
     public static int GetHashCode(this string target, StringComparison comparisonType) =>
         FromComparison(comparisonType).GetHashCode(target);
 
@@ -58,7 +58,7 @@ static partial class Polyfill
     /// <param name="value">The string to seek.</param>
     /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
     /// <returns>true if the value parameter occurs within this string, or if value is the empty string (""); otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-string-system-stringcomparison)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-string-system-stringcomparison)
     public static bool Contains(this string target, string value, StringComparison comparisonType) =>
         target.IndexOf(value, comparisonType) >= 0;
 
@@ -68,7 +68,7 @@ static partial class Polyfill
     /// <param name="value">The character to compare.</param>
     /// <remarks>This method performs an ordinal (case-sensitive and culture-insensitive) comparison.</remarks>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-char)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-char)
     public static bool StartsWith(this string target, char value)
     {
         if (target.Length == 0)
@@ -85,7 +85,7 @@ static partial class Polyfill
     /// <param name="value">The character to seek.</param>
     /// <remarks>This method performs an ordinal (case-sensitive and culture-insensitive) comparison.</remarks>
     /// <returns>true if the value parameter occurs within this string; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-char)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-char)
     public static bool EndsWith(this string target, char value)
     {
         if (target.Length == 0)
@@ -107,7 +107,7 @@ static partial class Polyfill
     /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings
     /// and include empty substrings.</param>
     /// <returns>An array that contains at most count substrings from this instance that are delimited by separator.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.split#system-string-split(system-char-system-stringsplitoptions)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.split#system-string-split(system-char-system-stringsplitoptions)
     public static string[] Split(this string target, char separator, StringSplitOptions options = StringSplitOptions.None) =>
         target.Split([separator], options);
 
@@ -121,7 +121,7 @@ static partial class Polyfill
     /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings
     /// and include empty substrings.</param>
     /// <returns>An array that contains at most count substrings from this instance that are delimited by separator.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.split#system-string-split(system-char-system-int32-system-stringsplitoptions)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.split#system-string-split(system-char-system-int32-system-stringsplitoptions)
     public static string[] Split(this string target, char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
         target.Split([separator], count, options);
 #endif
@@ -133,7 +133,7 @@ static partial class Polyfill
     /// <remarks>This method performs an ordinal (case-sensitive and culture-insensitive) comparison.</remarks>
     /// <param name="value">The character to seek.</param>
     /// <returns>true if the value parameter occurs within this string; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-char)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.contains#system-string-contains(system-char)
     public static bool Contains(this string target, char value) =>
         target.IndexOf(value) >= 0;
 #endif

--- a/src/Polyfill/Polyfill_StringBuilder.cs
+++ b/src/Polyfill/Polyfill_StringBuilder.cs
@@ -21,7 +21,7 @@ static partial class Polyfill
     /// and span are equal.
     /// </remarks>
     /// <returns>true if the characters in this instance and span are the same; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.equals#system-text-stringbuilder-equals(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.equals#system-text-stringbuilder-equals(system-readonlyspan((system-char)))
     public static bool Equals(this StringBuilder target, ReadOnlySpan<char> span)
     {
         if (target.Length != span.Length)
@@ -55,7 +55,7 @@ static partial class Polyfill
     /// <remarks>
     /// If <paramref name="newValue"/> is <c>null</c>, instances of <paramref name="oldValue"/> are removed from this builder.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.replace#system-text-stringbuilder-replace(system-readonlyspan((system-char))-system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.replace#system-text-stringbuilder-replace(system-readonlyspan((system-char))-system-readonlyspan((system-char)))
     public static StringBuilder Replace(this StringBuilder target, ReadOnlySpan<char> oldValue, ReadOnlySpan<char> newValue) =>
         target.Replace(oldValue.ToString(), newValue.ToString());
 
@@ -69,7 +69,7 @@ static partial class Polyfill
     /// <remarks>
     /// If <paramref name="newValue"/> is empty, instances of <paramref name="oldValue"/> are removed from this builder.
     /// </remarks>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.replace#system-text-stringbuilder-replace(system-char-system-char-system-int32-system-int32)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.replace#system-text-stringbuilder-replace(system-char-system-char-system-int32-system-int32)
     public static StringBuilder Replace(this StringBuilder target, ReadOnlySpan<char> oldValue, ReadOnlySpan<char> newValue, int startIndex, int count) =>
         target.Replace(oldValue.ToString(), newValue.ToString(), startIndex, count);
 #endif

--- a/src/Polyfill/Polyfill_StringBuilder_Append.cs
+++ b/src/Polyfill/Polyfill_StringBuilder_Append.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="value">The read-only character span to append.</param>
     /// <returns>A reference to this instance after the append operation is completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-readonlyspan((system-char)))
     public static StringBuilder Append(this StringBuilder target, ReadOnlySpan<char> value)
     {
         if (value.Length <= 0)
@@ -45,7 +45,7 @@ static partial class Polyfill
     /// <summary>Appends the specified interpolated string to this instance.</summary>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder Append(
         StringBuilder target,
         [InterpolatedStringHandlerArgument(nameof(target))]
@@ -55,7 +55,7 @@ static partial class Polyfill
     /// <param name="provider">An object that supplies culture-specific formatting information.</param>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder Append(
         StringBuilder target,
         IFormatProvider? provider,
@@ -65,7 +65,7 @@ static partial class Polyfill
     /// <summary>Appends the specified interpolated string followed by the default line terminator to the end of the current StringBuilder object.</summary>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder AppendLine(
         StringBuilder target,
         [InterpolatedStringHandlerArgument(nameof(target))]
@@ -76,7 +76,7 @@ static partial class Polyfill
     /// <param name="provider">An object that supplies culture-specific formatting information.</param>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder AppendLine(
         StringBuilder target,
         IFormatProvider? provider,
@@ -89,7 +89,7 @@ static partial class Polyfill
     /// <summary>Appends the specified interpolated string to this instance.</summary>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder Append(
         StringBuilder target,
         [InterpolatedStringHandlerArgument(nameof(target))] ref StringBuilder.AppendInterpolatedStringHandler handler) =>
@@ -99,7 +99,7 @@ static partial class Polyfill
     /// <param name="provider">An object that supplies culture-specific formatting information.</param>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append#system-text-stringbuilder-append(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder Append(
         StringBuilder target,
         IFormatProvider? provider,
@@ -109,7 +109,7 @@ static partial class Polyfill
     /// <summary>Appends the specified interpolated string followed by the default line terminator to the end of the current StringBuilder object.</summary>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder AppendLine(
         StringBuilder target,
         [InterpolatedStringHandlerArgument(nameof(target))] ref StringBuilder.AppendInterpolatedStringHandler handler) =>
@@ -119,7 +119,7 @@ static partial class Polyfill
     /// <param name="provider">An object that supplies culture-specific formatting information.</param>
     /// <param name="handler">The interpolated string to append.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline#system-text-stringbuilder-appendline(system-iformatprovider-system-text-stringbuilder-appendinterpolatedstringhandler@)
     public static StringBuilder AppendLine(
         StringBuilder target,
         IFormatProvider? provider,

--- a/src/Polyfill/Polyfill_StringBuilder_AppendJoin.cs
+++ b/src/Polyfill/Polyfill_StringBuilder_AppendJoin.cs
@@ -16,7 +16,7 @@ static partial class Polyfill
     /// <param name="separator">The string to use as a separator. separator is included in the joined strings only if values has more than one element.</param>
     /// <param name="values">An array that contains the strings to concatenate and append to the current instance of the string builder.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-string-system-string())")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-string-system-string())
     public static StringBuilder AppendJoin(
         this StringBuilder target,
         string separator,
@@ -27,7 +27,7 @@ static partial class Polyfill
     /// <param name="separator">The string to use as a separator. separator is included in the joined strings only if values has more than one element.</param>
     /// <param name="values">An array that contains the strings to concatenate and append to the current instance of the string builder.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-string-system-object())")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-string-system-object())
     public static StringBuilder AppendJoin(
         this StringBuilder target,
         string separator,
@@ -38,7 +38,7 @@ static partial class Polyfill
     /// <param name="separator">The character to use as a separator. separator is included in the joined strings only if values has more than one element.</param>
     /// <param name="values">An array that contains the strings to concatenate and append to the current instance of the string builder.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-char-system-string())")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-char-system-string())
     public static StringBuilder AppendJoin(
         this StringBuilder target,
         char separator,
@@ -49,7 +49,7 @@ static partial class Polyfill
     /// <param name="separator">The character to use as a separator. separator is included in the joined strings only if values has more than one element.</param>
     /// <param name="values">An array that contains the strings to concatenate and append to the current instance of the string builder.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-char-system-object())")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin(system-char-system-object())
     public static StringBuilder AppendJoin(
         this StringBuilder target,
         char separator,
@@ -60,7 +60,7 @@ static partial class Polyfill
     /// <param name="separator">The character to use as a separator. separator is included in the joined strings only if values has more than one element.</param>
     /// <param name="values">A collection that contains the objects to concatenate and append to the current instance of the string builder.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin-1(system-char-system-collections-generic-ienumerable((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin-1(system-char-system-collections-generic-ienumerable((-0)))
     public static StringBuilder AppendJoin<T>(
         this StringBuilder target,
         char separator,
@@ -71,7 +71,7 @@ static partial class Polyfill
     /// <param name="separator">The string to use as a separator. separator is included in the concatenated and appended strings only if values has more than one element.</param>
     /// <param name="values">A collection that contains the objects to concatenate and append to the current instance of the string builder.</param>
     /// <returns>A reference to this instance after the append operation has completed.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin-1(system-string-system-collections-generic-ienumerable((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendjoin#system-text-stringbuilder-appendjoin-1(system-string-system-collections-generic-ienumerable((-0)))
     public static StringBuilder AppendJoin<T>(
         this StringBuilder target,
         string separator,

--- a/src/Polyfill/Polyfill_StringBuilder_CopyTo.cs
+++ b/src/Polyfill/Polyfill_StringBuilder_CopyTo.cs
@@ -17,7 +17,7 @@ static partial class Polyfill
     /// <param name="sourceIndex">The starting position in this instance where characters will be copied from. The index is zero-based.</param>
     /// <param name="destination">The writable span where characters will be copied.</param>
     /// <param name="count">The number of characters to be copied.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.copyto#system-text-stringbuilder-copyto(system-int32-system-span((system-char))-system-int32)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.copyto#system-text-stringbuilder-copyto(system-int32-system-span((system-char))-system-int32)
     public static void CopyTo(
         this StringBuilder target,
         int sourceIndex,

--- a/src/Polyfill/Polyfill_StringBuilder_GetChunks.cs
+++ b/src/Polyfill/Polyfill_StringBuilder_GetChunks.cs
@@ -64,7 +64,7 @@ static partial class Polyfill
     ///             { /* operation on span[i] */ }
     ///    }
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.getchunks")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.getchunks
     public static ChunkEnumerator GetChunks(this StringBuilder target) =>
         new(target);
 

--- a/src/Polyfill/Polyfill_Task.cs
+++ b/src/Polyfill/Polyfill_Task.cs
@@ -18,14 +18,14 @@ static partial class Polyfill
     /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
     /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken)
     public static Task WaitAsync(this Task target, CancellationToken cancellationToken) =>
         target.WaitAsync(Timeout.InfiniteTimeSpan, cancellationToken);
 
     /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified timeout expires.</summary>
     /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
     /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-timespan)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-timespan)
     public static Task WaitAsync(
         this Task target,
         TimeSpan timeout) =>
@@ -35,7 +35,7 @@ static partial class Polyfill
     /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
     /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-timespan-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-timespan-system-threading-cancellationtoken)
     public static Task WaitAsync(
         this Task target,
         TimeSpan timeout,
@@ -91,7 +91,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
     /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.waitasync#system-threading-tasks-task-waitasync(system-threading-cancellationtoken)
     public static Task<TResult> WaitAsync<TResult>(
         this Task<TResult> target,
         CancellationToken cancellationToken) =>
@@ -102,7 +102,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
     /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan)
     public static Task<TResult> WaitAsync<TResult>(
         this Task<TResult> target,
         TimeSpan timeout) =>
@@ -114,7 +114,7 @@ static partial class Polyfill
     /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
     /// <returns>The <see cref="Task"/> representing the asynchronous wait.  It may or may not be the same instance as the current instance.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1.waitasync#system-threading-tasks-task-1-waitasync(system-timespan-system-threading-cancellationtoken)
     public static async Task<TResult> WaitAsync<TResult>(
         this Task<TResult> target,
         TimeSpan timeout,

--- a/src/Polyfill/Polyfill_TaskCompletionSource.cs
+++ b/src/Polyfill/Polyfill_TaskCompletionSource.cs
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// <see cref="TaskStatus.Faulted"/>, or
     /// <see cref="TaskStatus.Canceled"/>.
     /// </exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcompletionsource-1.setcanceled#system-threading-tasks-taskcompletionsource-1-setcanceled(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcompletionsource-1.setcanceled#system-threading-tasks-taskcompletionsource-1-setcanceled(system-threading-cancellationtoken)
     public static void SetCanceled<T>(
         this TaskCompletionSource<T> target,
         CancellationToken cancellationToken)

--- a/src/Polyfill/Polyfill_TextReader.cs
+++ b/src/Polyfill/Polyfill_TextReader.cs
@@ -29,7 +29,7 @@ static partial class Polyfill
     /// The number will be less than or equal to the <paramref name="buffer"/> length, depending on whether the data is
     /// available within the stream.
     /// </returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textreader.readasync#system-io-textreader-readasync(system-memory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textreader.readasync#system-io-textreader-readasync(system-memory((system-char))-system-threading-cancellationtoken)
     public static ValueTask<int> ReadAsync(
         this TextReader target,
         Memory<char> buffer,
@@ -58,7 +58,7 @@ static partial class Polyfill
     /// <exception cref="ArgumentOutOfRangeException">The number of characters is larger than <see cref="int.MaxValue"/>.</exception>
     /// <exception cref="ObjectDisposedException">The stream reader has been disposed.</exception>
     /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textreader.readtoendasync#system-io-textreader-readtoendasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textreader.readtoendasync#system-io-textreader-readtoendasync(system-threading-cancellationtoken)
     public static Task<string> ReadToEndAsync(
         this TextReader target,
         CancellationToken cancellationToken)
@@ -78,7 +78,7 @@ static partial class Polyfill
     /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
     /// <exception cref="ObjectDisposedException">The text reader has been disposed.</exception>
     /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textreader.readtoendasync#system-io-textreader-readlineasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textreader.readtoendasync#system-io-textreader-readlineasync(system-threading-cancellationtoken)
     public static Task<string> ReadLineAsync(
         this TextReader target,
         CancellationToken cancellationToken)

--- a/src/Polyfill/Polyfill_TextWriter.cs
+++ b/src/Polyfill/Polyfill_TextWriter.cs
@@ -28,7 +28,7 @@ static partial class Polyfill
     /// <returns>A <see cref="Task"/> that represents the asynchronous flush operation.</returns>
     /// <exception cref="ObjectDisposedException">The text writer is disposed.</exception>
     /// <exception cref="InvalidOperationException">The writer is currently in use by a previous write operation.</exception>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flushasync#system-io-textwriter-flushasync(system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.flushasync#system-io-textwriter-flushasync(system-threading-cancellationtoken)
     public static Task FlushAsync(this TextWriter target, CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
@@ -48,7 +48,7 @@ static partial class Polyfill
     /// StringBuilder.GetChunks() method to avoid creating the intermediate string
     /// </summary>
     /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-text-stringbuilder)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-text-stringbuilder)
     public static void Write(this TextWriter target, StringBuilder? value)
     {
         if (value == null)
@@ -72,7 +72,7 @@ static partial class Polyfill
     /// </summary>
     /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)
     public static Task WriteAsync(this TextWriter target, StringBuilder? value, CancellationToken cancellationToken = default)
     {
         if (cancellationToken.IsCancellationRequested)
@@ -114,7 +114,7 @@ static partial class Polyfill
     /// The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeasync#system-io-textwriter-writeasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)
     public static ValueTask WriteAsync(
         this TextWriter target,
         ReadOnlyMemory<char> buffer,
@@ -142,7 +142,7 @@ static partial class Polyfill
     /// The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync#system-io-textwriter-writelineasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writelineasync#system-io-textwriter-writelineasync(system-readonlymemory((system-char))-system-threading-cancellationtoken)
     public static ValueTask WriteLineAsync(
         this TextWriter target,
         ReadOnlyMemory<char> buffer,
@@ -167,7 +167,7 @@ static partial class Polyfill
     /// Writes a character span to the text stream.
     /// </summary>
     /// <param name="buffer">The character span to write.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write#system-io-textwriter-write(system-readonlyspan((system-char)))
     public static void Write(
         this TextWriter target,
         ReadOnlySpan<char> buffer)
@@ -190,7 +190,7 @@ static partial class Polyfill
     /// Writes the text representation of a character span to the text stream, followed by a line terminator.
     /// </summary>
     /// <param name="buffer">The char span value to write to the text stream.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline#system-io-textwriter-writeline(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline#system-io-textwriter-writeline(system-readonlyspan((system-char)))
     public static void WriteLine(
         this TextWriter target,
         ReadOnlySpan<char> buffer)

--- a/src/Polyfill/Polyfill_TryFormat.cs
+++ b/src/Polyfill/Polyfill_TryFormat.cs
@@ -13,7 +13,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance as UTF-8 into the provided span of bytes.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.timespan.tryformat#system-timespan-tryformat(system-span((system-byte))-system-int32@-system-readonlyspan((system-char))-system-iformatprovider)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.timespan.tryformat#system-timespan-tryformat(system-span((system-byte))-system-int32@-system-readonlyspan((system-char))-system-iformatprovider)
     public static bool TryFormat(this TimeSpan target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? formatProvider = null)
     {
         string result;
@@ -33,7 +33,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance as UTF-8 into the provided span of bytes.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryformat#system-guid-tryformat(system-span((system-char))-system-int32@-system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryformat#system-guid-tryformat(system-span((system-char))-system-int32@-system-readonlyspan((system-char)))
     public static bool TryFormat(this Guid target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default)
     {
         string result;
@@ -53,7 +53,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.sbyte.tryformat
     public static bool TryFormat(
         this sbyte target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
@@ -74,7 +74,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.byte.tryformat
     public static bool TryFormat(this byte target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -94,7 +94,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int16.tryformat
     public static bool TryFormat(this short target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -114,7 +114,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint16.tryformat
     public static bool TryFormat(this ushort target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -134,7 +134,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryformat
     public static bool TryFormat(this int target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -154,7 +154,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint32.tryformat
     public static bool TryFormat(this uint target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -174,7 +174,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.int64.tryformat
     public static bool TryFormat(this long target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -194,7 +194,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.uint64.tryformat
     public static bool TryFormat(this ulong target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -214,7 +214,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.single.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.single.tryformat
     public static bool TryFormat(this float target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -234,7 +234,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.double.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.double.tryformat
     public static bool TryFormat(this double target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -254,7 +254,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.decimal.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.decimal.tryformat
     public static bool TryFormat(this decimal target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -274,7 +274,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.boolean.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.boolean.tryformat
     public static bool TryFormat(this bool target, Span<char> destination, out int charsWritten)
     {
         var result = target.ToString();
@@ -286,7 +286,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryformat
     public static bool TryFormat(this DateTimeOffset target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -306,7 +306,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryformat
     public static bool TryFormat(this DateTime target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -329,7 +329,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.dateonly.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.dateonly.tryformat
     public static bool TryFormat(this DateOnly target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;
@@ -349,7 +349,7 @@ static partial class Polyfill
     /// <summary>
     /// Tries to format the value of the current instance into the provided span of characters.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.timeonly.tryformat")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.timeonly.tryformat
     public static bool TryFormat(this TimeOnly target, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
     {
         string result;

--- a/src/Polyfill/Polyfill_Type.cs
+++ b/src/Polyfill/Polyfill_Type.cs
@@ -14,15 +14,15 @@ using Link = System.ComponentModel.DescriptionAttribute;
 static partial class Polyfill
 {
 #if NETFRAMEWORK || NETSTANDARD2_0 || NETCOREAPP2_0
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.hassamemetadatadefinitionas")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.hassamemetadatadefinitionas
     public static bool HasSameMetadataDefinitionAs(this MemberInfo target, MemberInfo other) =>
         target.MetadataToken == other.MetadataToken &&
         target.Module.Equals(other.Module);
 #endif
 
 #if !NET9_0_OR_GREATER && !NETFRAMEWORK && !NETSTANDARD2_0 && !NETCOREAPP2_0
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethod#system-type-getmethod(system-string-system-int32-system-reflection-bindingflags-system-type())
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethod#system-type-getmethod(system-string-system-int32-system-reflection-bindingflags-system-type())")]
     public static MethodInfo? GetMethod(this Type target, string name, int genericParameterCount, BindingFlags bindingAttr, Type[] types) =>
         target.GetMethod(name, genericParameterCount, bindingAttr, null, types, null);
 #endif
@@ -30,7 +30,7 @@ static partial class Polyfill
     /// <summary>
     /// Gets a value that indicates whether the current Type represents a type parameter in the definition of a generic method.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.type.isgenericmethodparameter")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.type.isgenericmethodparameter
     public static bool IsGenericMethodParameter(this Type target) =>
 #if NETFRAMEWORK || NETSTANDARD2_0 || NETCOREAPP2_0
         target.IsGenericParameter &&
@@ -55,7 +55,7 @@ static partial class Polyfill
     /// <summary>
     /// Determines whether the current type can be assigned to a variable of the specified targetType.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.type.isassignableto")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.type.isassignableto
     public static bool IsAssignableTo(this Type target, [NotNullWhen(true)] Type? targetType) =>
         targetType?.IsAssignableFrom(target) ?? false;
 #endif
@@ -68,7 +68,7 @@ static partial class Polyfill
     /// <param name="type">The MemberInfo to find on the current Type.</param>
     /// <param name="member">The MemberInfo to find on the current Type.</param>
     /// <returns>An object representing the member on the current Type that matches the specified member.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.type.getmemberwithsamemetadatadefinitionas")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.type.getmemberwithsamemetadatadefinitionas
     internal static MemberInfo GetMemberWithSameMetadataDefinitionAs(
         this Type type,
         MemberInfo member)

--- a/src/Polyfill/Polyfill_XDocument.cs
+++ b/src/Polyfill/Polyfill_XDocument.cs
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// <param name="cancellationToken">
     /// A cancellation token.
     /// </param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument.saveasync#system-xml-linq-xdocument-saveasync(system-xml-xmlwriter-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument.saveasync#system-xml-linq-xdocument-saveasync(system-xml-xmlwriter-system-threading-cancellationtoken)
     public static Task SaveAsync(
         this XDocument target,
         XmlWriter writer,
@@ -45,7 +45,7 @@ static partial class Polyfill
     /// If SaveOptions.OmitDuplicateNamespaces is enabled duplicate namespace declarations will be removed.
     /// </param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument.saveasync#system-xml-linq-xdocument-saveasync(system-io-stream-system-xml-linq-saveoptions-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument.saveasync#system-xml-linq-xdocument-saveasync(system-io-stream-system-xml-linq-saveoptions-system-threading-cancellationtoken)
     public static Task SaveAsync(
         this XDocument target,
         Stream stream,
@@ -68,7 +68,7 @@ static partial class Polyfill
     /// If SaveOptions.OmitDuplicateNamespaces is enabled duplicate namespace declarations will be removed.
     /// </param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument.saveasync#system-xml-linq-xdocument-saveasync(system-io-textwriter-system-xml-linq-saveoptions-system-threading-cancellationtoken)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument.saveasync#system-xml-linq-xdocument-saveasync(system-io-textwriter-system-xml-linq-saveoptions-system-threading-cancellationtoken)
     public static Task SaveAsync(
         this XDocument target,
         TextWriter textWriter,

--- a/src/Polyfill/Regex/Polyfill_Regex.cs
+++ b/src/Polyfill/Regex/Polyfill_Regex.cs
@@ -15,7 +15,7 @@ static partial class Polyfill
     /// Indicates whether the regular expression specified in the Regex constructor finds a match in a specified input span.
     /// </summary>
     /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-int32)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-int32)
     public static bool IsMatch(this Regex target, ReadOnlySpan<char> input, int startat) =>
         target.IsMatch(input.ToString(), startat);
 
@@ -23,7 +23,7 @@ static partial class Polyfill
     /// Indicates whether the regular expression specified in the Regex constructor finds a match in a specified input span.
     /// </summary>
     /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char)))
     public static bool IsMatch(this Regex target, ReadOnlySpan<char> input) =>
         target.IsMatch(input.ToString());
 
@@ -31,7 +31,7 @@ static partial class Polyfill
     /// Searches an input span for all occurrences of a regular expression and returns a Regex.ValueMatchEnumerator to iterate over the matches.
     /// </summary>
     /// <returns>A Regex.ValueMatchEnumerator to iterate over the matches.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char)))
     public static ValueMatchEnumerator EnumerateMatches (this Regex target, ReadOnlySpan<char> input) =>
         new(target, input, target.RightToLeft ? input.Length : 0);
 
@@ -39,7 +39,7 @@ static partial class Polyfill
     /// Searches an input span for all occurrences of a regular expression and returns a Regex.ValueMatchEnumerator to iterate over the matches.
     /// </summary>
     /// <returns>A Regex.ValueMatchEnumerator to iterate over the matches.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-int32)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-int32)
     public static ValueMatchEnumerator EnumerateMatches (this Regex target, ReadOnlySpan<char> input, int startat) =>
         new(target, input, startat);
 }

--- a/src/Polyfill/Regex/RegexPolyfill.cs
+++ b/src/Polyfill/Regex/RegexPolyfill.cs
@@ -29,7 +29,7 @@ public
     /// Indicates whether the specified regular expression finds a match in the specified input span, using the specified matching options and time-out interval.
     /// </summary>
     /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions-system-timespan)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions-system-timespan)
     public static bool IsMatch(ReadOnlySpan<char> input, string pattern, RegexOptions options, TimeSpan timeout)
     {
 #if NET7_0_OR_GREATER
@@ -43,7 +43,7 @@ public
     /// Indicates whether the specified regular expression finds a match in the specified input span, using the specified matching options.
     /// </summary>
     /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions)
     public static bool IsMatch(ReadOnlySpan<char> input, string pattern, RegexOptions options)
     {
 #if NET7_0_OR_GREATER
@@ -57,7 +57,7 @@ public
     /// Indicates whether the specified regular expression finds a match in the specified input span.
     /// </summary>
     /// <returns>true if the regular expression finds a match; otherwise, false.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-string)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch#system-text-regularexpressions-regex-ismatch(system-readonlyspan((system-char))-system-string)
     public static bool IsMatch(ReadOnlySpan<char> input, string pattern)
     {
 #if NET7_0_OR_GREATER
@@ -71,7 +71,7 @@ public
     /// Searches an input span for all occurrences of a regular expression and returns a Regex.ValueMatchEnumerator to iterate over the matches.
     /// </summary>
     /// <returns>A Regex.ValueMatchEnumerator to iterate over the matches.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-string)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-string)
     public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, string pattern)
     {
 #if NET7_0_OR_GREATER
@@ -85,7 +85,7 @@ public
     /// Searches an input span for all occurrences of a regular expression and returns a Regex.ValueMatchEnumerator to iterate over the matches.
     /// </summary>
     /// <returns>A Regex.ValueMatchEnumerator to iterate over the matches.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions-system-timespan)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions-system-timespan)
     public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, string pattern, RegexOptions options, TimeSpan timeout)
     {
 #if NET7_0_OR_GREATER
@@ -99,7 +99,7 @@ public
     /// Searches an input span for all occurrences of a regular expression and returns a Regex.ValueMatchEnumerator to iterate over the matches.
     /// </summary>
     /// <returns>A Regex.ValueMatchEnumerator to iterate over the matches.</returns>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.enumeratematches#system-text-regularexpressions-regex-enumeratematches(system-readonlyspan((system-char))-system-string-system-text-regularexpressions-regexoptions)
     public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, string pattern, RegexOptions options)
     {
 #if NET7_0_OR_GREATER

--- a/src/Polyfill/RequiresPreviewFeaturesAttribute .cs
+++ b/src/Polyfill/RequiresPreviewFeaturesAttribute .cs
@@ -26,7 +26,7 @@ using Link = System.ComponentModel.DescriptionAttribute;
     Inherited = false)]
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.requirespreviewfeaturesattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.requirespreviewfeaturesattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/SpanLineEnumerator.cs
+++ b/src/Polyfill/SpanLineEnumerator.cs
@@ -19,7 +19,7 @@ using Link = ComponentModel.DescriptionAttribute;
 /// </remarks>
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.text.spanlineenumerator")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.text.spanlineenumerator
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/StringInterpolation/DefaultInterpolatedStringHandler.cs
+++ b/src/Polyfill/StringInterpolation/DefaultInterpolatedStringHandler.cs
@@ -18,7 +18,7 @@ using Link = ComponentModel.DescriptionAttribute;
 [InterpolatedStringHandler]
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.defaultinterpolatedstringhandler")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.defaultinterpolatedstringhandler
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/StringInterpolation/ISpanFormattable.cs
+++ b/src/Polyfill/StringInterpolation/ISpanFormattable.cs
@@ -10,7 +10,7 @@ using Link = System.ComponentModel.DescriptionAttribute;
 namespace System;
 
 /// <summary>Provides functionality to format the string representation of an object into a span.</summary>
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.ispanformattable")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.ispanformattable
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/StringInterpolation/InterpolatedStringHandlerArgumentAttribute.cs
+++ b/src/Polyfill/StringInterpolation/InterpolatedStringHandlerArgumentAttribute.cs
@@ -15,7 +15,7 @@ using Link = ComponentModel.DescriptionAttribute;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter)]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.interpolatedstringhandlerargumentattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.interpolatedstringhandlerargumentattribute
 #if PolyPublic
 public
 #endif

--- a/src/Polyfill/StringInterpolation/InterpolatedStringHandlerAttribute.cs
+++ b/src/Polyfill/StringInterpolation/InterpolatedStringHandlerAttribute.cs
@@ -14,7 +14,7 @@ using Targets = AttributeTargets;
 /// <summary>
 /// Indicates the attributed type is to be used as an interpolated string handler.
 /// </summary>
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.interpolatedstringhandlerargumentattribute")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.interpolatedstringhandlerargumentattribute
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(

--- a/src/Polyfill/StringPolyfill.cs
+++ b/src/Polyfill/StringPolyfill.cs
@@ -18,7 +18,7 @@ static partial class StringPolyfill
     /// <summary>
     /// Concatenates an array of strings, using the specified separator between each member.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join(system-char-system-string())")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join(system-char-system-string())
     public static string Join(char separator, string[] values) =>
 #if NETSTANDARD2_0 || NETFRAMEWORK
         string.Join(new([separator]), values);
@@ -29,7 +29,7 @@ static partial class StringPolyfill
     /// <summary>
     /// Concatenates the string representations of an array of objects, using the specified separator between each member.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join(system-char-system-object())")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join(system-char-system-object())
     public static string Join(char separator, object[] values) =>
 #if NETSTANDARD2_0 || NETFRAMEWORK
         string.Join(new([separator]), values);
@@ -40,7 +40,7 @@ static partial class StringPolyfill
     /// <summary>
     /// Concatenates the specified elements of a string array, using the specified separator between each element.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join(system-char-system-string()-system-int32-system-int32)")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join(system-char-system-string()-system-int32-system-int32)
     public static string Join(char separator, string?[] value, int startIndex, int count) =>
 #if NETSTANDARD2_0 || NETFRAMEWORK
         string.Join(new([separator]), value, startIndex, count);
@@ -51,7 +51,7 @@ static partial class StringPolyfill
     /// <summary>
     /// Concatenates the specified elements of a string array, using the specified separator between each element.
     /// </summary>
-    [Link("https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join-1(system-char-system-collections-generic-ienumerable((-0)))")]
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.join#system-string-join-1(system-char-system-collections-generic-ienumerable((-0)))
     public static string Join<T>(char separator, IEnumerable<T> values) =>
 #if NETSTANDARD2_0 || NETFRAMEWORK
         string.Join(new([separator]), values);

--- a/src/Polyfill/TaskCompletionSource.cs
+++ b/src/Polyfill/TaskCompletionSource.cs
@@ -37,7 +37,7 @@ using Link = System.ComponentModel.DescriptionAttribute;
 /// </remarks>
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
-[Link("https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcompletionsource?view=net-8.0")]
+//Link: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcompletionsource?view=net-8.0
 #if PolyPublic
 public
 #endif


### PR DESCRIPTION
the link (description) attribute is only used for generate docs

moving from an attribute (to a comment) reduces the size of the consuming assembly by  17.4kb