### PR TITLE
Fix typo: incorrect nuget package name in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1344,7 +1344,7 @@ If using ValueTask APIs and consuming in a project that target `netframework`, `
 If using the RuntimeInformation class or OSPlatform struct and consuming in a project that targets `netframework`, a reference to [System.Runtime.InteropServices.RuntimeInformation](https://www.nuget.org/packages/System.Runtime.InteropServices.RuntimeInformation) nuget is required.
 
 ```xml
-<PackageReference Include="System.Runtime.InteropService.RuntimeInformation"
+<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation"
                   Version="4.3.0"
                   Condition="$(TargetFrameworkIdentifier) == '.NETFramework'" />
 ```


### PR DESCRIPTION
The package Id in `System.Runtime.InteropServices` section in [readme.md](https://github.com/SimonCropp/Polyfill/blob/main/readme.md#systemruntimeinteropservices) seems missing the `s` at the end in `interopservice`: https://www.nuget.org/packages/system.runtime.interopservices.runtimeinformation/