### PR TITLE
Add String ``Split(string, StringSplitOptions)`` and ``Split(string, int, StringSplitOptions)`` extension methods

### DIFF
--- a/apiCount.include.md
+++ b/apiCount.include.md
@@ -1,1 +1,1 @@
-**API count: 575**
+**API count: 577**

--- a/readme.md
+++ b/readme.md
@@ -907,6 +907,8 @@ The class `Polyfill` includes the following extension methods:
  * `string ReplaceLineEndings()` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.replacelineendings?view=net-10.0#system-string-replacelineendings)
  * `string[] Split(char, int, StringSplitOptions)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-char-system-int32-system-stringsplitoptions))
  * `string[] Split(char, StringSplitOptions)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-char-system-stringsplitoptions))
+ * `string[] Split(string, int, StringSplitOptions)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-string-system-int32-system-stringsplitoptions))
+ * `string[] Split(string, StringSplitOptions)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-string-system-stringsplitoptions))
  * `bool StartsWith(char)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.startswith?view=net-10.0#system-string-startswith(system-char))
  * `bool TryCopyTo(Span<char>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.trycopyto?view=net-10.0)
 

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -633,9 +633,13 @@ class Consume
     {
         var contains = "a b".Contains(' ');
         var endsWith = "value".EndsWith('a');
-        var split = "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        split = "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+        var splitChar = "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        splitChar = "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
         var startsWith = "value".StartsWith('a');
+
+        var splitString = "a b".Split(" ", StringSplitOptions.RemoveEmptyEntries);
+        splitString = "a b".Split(" ", 2, StringSplitOptions.RemoveEmptyEntries);
     }
 
     #if !NoStringInterpolation && FeatureMemory

--- a/src/Polyfill/Polyfill_String.cs
+++ b/src/Polyfill/Polyfill_String.cs
@@ -98,10 +98,9 @@ static partial class Polyfill
         return target[lastPos] == value;
     }
 
+
     /// <summary>
-    /// Splits a string into a maximum number of substrings based on a specified delimiting character and, optionally,
-    /// options. Splits a string into a maximum number of substrings based on the provided character separator,
-    /// optionally omitting empty substrings from the result.
+    /// Splits a string into substrings based on a specified delimiting character and, optionally, options.
     /// </summary>
     //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-char-system-stringsplitoptions)
     public static string[] Split(this string target, char separator, StringSplitOptions options = StringSplitOptions.None) =>

--- a/src/Polyfill/Polyfill_String.cs
+++ b/src/Polyfill/Polyfill_String.cs
@@ -114,6 +114,21 @@ static partial class Polyfill
     //Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-char-system-int32-system-stringsplitoptions)
     public static string[] Split(this string target, char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
         target.Split([separator], count, options);
+
+
+    /// <summary>
+    /// Splits a string into substrings that are based on the provided string separator.
+    /// </summary>
+    /// Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-string-system-stringsplitoptions)
+    public static string[] Split(this string target, string separator, StringSplitOptions options = StringSplitOptions.None) =>
+        target.Split([separator], options);
+
+    /// <summary>
+    /// Splits a string into a maximum number of substrings based on a specified delimiting string and, optionally, options.
+    /// </summary>
+    /// Link: https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-10.0#system-string-split(system-string-system-int32-system-stringsplitoptions)
+    public static string[] Split(this string target, string separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
+        target.Split([separator], count, options);
 #endif
 
 #if !NETCOREAPP2_1_OR_GREATER && !NETSTANDARD2_1_OR_GREATER

--- a/src/Tests/PolyfillTests_String.cs
+++ b/src/Tests/PolyfillTests_String.cs
@@ -56,6 +56,9 @@ partial class PolyfillTests
     {
         Assert.AreEqual(new []{"a","b"}, "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries));
         Assert.AreEqual(new []{"a","b"}, "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries));
+
+        Assert.AreEqual(new []{"a","b"}, "a b".Split(" ", StringSplitOptions.RemoveEmptyEntries));
+        Assert.AreEqual(new []{"a","b"}, "a b".Split(" ", 2, StringSplitOptions.RemoveEmptyEntries));
     }
 
     [Test]


### PR DESCRIPTION
This PR adds 2 String Split extension methods to Polyfill that are present in .NET Standard 2.1 and .NET Core 2+ but not .NET Standard 2.0 or .NET Framework (any version), specifically ``Split(string, StringSplitOptions)`` and ``Split(string, int, StringSplitOptions)``.

I've also corrected an incorrect comment for the String ``Splitt(char, StringSplitOptions)`` extension method.

I've updated the String tests Split method to add the required tests.

```csharp
    [Test]
    public void Split()
    {

        Assert.AreEqual(new []{"a","b"}, "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries));
        Assert.AreEqual(new []{"a","b"}, "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries));

        Assert.AreEqual(new []{"a","b"}, "a b".Split(" ", StringSplitOptions.RemoveEmptyEntries));
        Assert.AreEqual(new []{"a","b"}, "a b".Split(" ", 2, StringSplitOptions.RemoveEmptyEntries));
    }
```

The documentation for the 2 extension methods has been added to the Readme.

I've also added the Consume tests and updated the String Methods method:
I renamed the original ``split`` variable to ``splitChar`` to avoid ambiguity.
```csharp

    void String_Methods()
    {
        var contains = "a b".Contains(' ');
        var endsWith = "value".EndsWith('a');

        var splitChar = "a b".Split(' ', StringSplitOptions.RemoveEmptyEntries);
        splitChar = "a b".Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
        var startsWith = "value".StartsWith('a');

        var splitString = "a b".Split(" ", StringSplitOptions.RemoveEmptyEntries);
        splitString = "a b".Split(" ", 2, StringSplitOptions.RemoveEmptyEntries);
    }
```

Thanks for continuing to update and maintain the library.