### PR TITLE
Polyfill `Random.Shared` using a similar technique to the BCL

### DIFF
--- a/src/Polyfill/RandomPolyfill.cs
+++ b/src/Polyfill/RandomPolyfill.cs
@@ -5,8 +5,9 @@ namespace Polyfills;
 
 using System;
 using System.Diagnostics;
-using System.Threading;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
@@ -25,45 +26,22 @@ static partial class RandomPolyfill
 #else
         new ThreadSafeRandom();
 
-    class ThreadSafeRandom : Random
+    sealed class ThreadSafeRandom : Random
     {
-        Lock locker = new();
+        [ThreadStatic]
+        private static Random? random;
 
-        public override int Next()
-        {
-            lock (locker)
-                return base.Next();
-        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Random Create() => random = new Random();
 
-        public override int Next(int maxValue)
-        {
-            lock (locker)
-                return base.Next(maxValue);
-        }
+        private static Random LocalRandom => random ?? Create();
 
-        public override int Next(int minValue, int maxValue)
-        {
-            lock (locker)
-                return base.Next(minValue, maxValue);
-        }
-
-        public override void NextBytes(byte[] buffer)
-        {
-            lock (locker)
-                base.NextBytes(buffer);
-        }
-
-        public override double NextDouble()
-        {
-            lock (locker)
-                return base.NextDouble();
-        }
-
-        protected override double Sample()
-        {
-            lock (locker)
-                return base.Sample();
-        }
+        public override int Next() => LocalRandom.Next();
+        public override int Next(int maxValue) => LocalRandom.Next(maxValue);
+        public override int Next(int minValue, int maxValue) => LocalRandom.Next(minValue, maxValue);
+        public override void NextBytes(byte[] buffer) => LocalRandom.NextBytes(buffer);
+        public override double NextDouble() => LocalRandom.NextDouble();
+        protected override double Sample() => throw new NotSupportedException();
     }
 #endif
 }


### PR DESCRIPTION
The BCL describes how it implements `Random.Shared` and why [here](https://github.com/dotnet/runtime/blob/6454b4c4b99c39fa896367a85a1367adc789a7c0/src/libraries/System.Private.CoreLib/src/System/Random.cs#L463-L474).

While this change does not enable the devirtualization and inlining that the BCL one does,[^1] the usage of a `[ThreadStatic]` does nonetheless show performance improvements over locking, especially for concurrent access (the following results are for calls to `Next()` and come from targeting `net48`):

```
| Method                      | Mean         | Error      | StdDev     | Ratio | RatioSD |
|---------------------------- |-------------:|-----------:|-----------:|------:|--------:|
| Polyfill_SingleThreaded     |     13.20 ns |   0.278 ns |   0.342 ns |  1.00 |    0.04 |
| ThreadStatic_SingleThreaded |     13.01 ns |   0.081 ns |   0.071 ns |  0.99 |    0.03 |
|                             |              |            |            |       |         |
| Polyfill_Multithreaded      | 13,664.90 ns | 268.562 ns | 560.589 ns |  1.00 |    0.06 |
| ThreadStatic_Multithreaded  |  8,778.63 ns | 154.686 ns | 332.978 ns |  0.64 |    0.04 |
```

<details>

<summary>Source</summary>

#### Program.cs

(In a console project targeting `net48`.)

```csharp
BenchmarkRunner.Run<Benchmarks>();

[GroupBenchmarksBy(BenchmarkDotNet.Configs.BenchmarkLogicalGroupRule.ByCategory)]
public class Benchmarks
{
    private const int Parallelism = 100;

    [Benchmark(Baseline = true), BenchmarkCategory("01_Single")]
    public int Polyfill_SingleThreaded() => RandomPolyfill_Old.Shared.Next();

    [Benchmark, BenchmarkCategory("01_Single")]
    public int ThreadStatic_SingleThreaded() => RandomPolyfill_New.Shared.Next();

    [Benchmark(Baseline = true), BenchmarkCategory("02_Multi")]
    public ParallelLoopResult Polyfill_Multithreaded() => Parallel.For(0, Parallelism, _ => RandomPolyfill_Old.Shared.Next());

    [Benchmark, BenchmarkCategory("02_Multi")]
    public ParallelLoopResult ThreadStatic_Multithreaded() => Parallel.For(0, Parallelism, _ => RandomPolyfill_New.Shared.Next());
}
```

#### Lib.cs

(In a library project targeting `netstandard2.0` and referencing the Polyfill package for `Lock`.)

```csharp
public static class RandomPolyfill_New
{
    public static Random Shared { get; } = new ThreadSafeRandom();

    sealed class ThreadSafeRandom : Random
    {
        [ThreadStatic]
        private static Random? random;

        [MethodImpl(MethodImplOptions.NoInlining)]
        private static Random Create() => random = new Random();

        private static Random LocalRandom => random ?? Create();

        public override int Next() => LocalRandom.Next();
        public override int Next(int maxValue) => LocalRandom.Next(maxValue);
        public override int Next(int minValue, int maxValue) => LocalRandom.Next(minValue, maxValue);
        public override void NextBytes(byte[] buffer) => LocalRandom.NextBytes(buffer);
        public override double NextDouble() => LocalRandom.NextDouble();
        protected override double Sample() => throw new NotSupportedException();
    }
}

public static class RandomPolyfill_Old
{
    public static Random Shared { get; } = new ThreadSafeRandom();

    class ThreadSafeRandom : Random
    {
        Lock locker = new();

        public override int Next()
        {
            lock (locker)
                return base.Next();
        }

        public override int Next(int maxValue)
        {
            lock (locker)
                return base.Next(maxValue);
        }

        public override int Next(int minValue, int maxValue)
        {
            lock (locker)
                return base.Next(minValue, maxValue);
        }

        public override void NextBytes(byte[] buffer)
        {
            lock (locker)
                base.NextBytes(buffer);
        }

        public override double NextDouble()
        {
            lock (locker)
                return base.NextDouble();
        }

        protected override double Sample()
        {
            lock (locker)
                return base.Sample();
        }
    }
}
```

</details>

[^1]: Because we're still using `Random`, not a sealed subclass like `XoshiroImpl`; plus, I don't think those JIT improvements are even available on netfx anyway?