### PR TITLE
Include Microsoft.Bcl.Memory in PolyfillLib

### DIFF
--- a/src/PolyfillLib/PolyfillLib.csproj
+++ b/src/PolyfillLib/PolyfillLib.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="$(TargetFramework) == 'netstandard2.0' or $(TargetFramework) == 'netcoreapp2.0' or $(TargetFrameworkIdentifier) == '.NETFramework'" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Condition="$(TargetFramework.StartsWith('net4'))" />
     <PackageReference Include="System.IO.Compression" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" />
   </ItemGroup>
   <Import Project="$(SolutionDir)\TestIncludes.targets" />
   <Import Project="$(SolutionDir)\Polyfill\Polyfill.targets" />


### PR DESCRIPTION
This prevents duplicate definitions of `Index` and `Range` on .NET Framework.

Microsoft.Bcl.Memory also includes `Base64Url`.
To prevent inconsistent availability of that class across target frameworks I chose to include the package on all frameworks before net9.0.

Fixes #394.