### PR TITLE
Refactor Android OS detection to use RuntimeInformation

### DIFF
--- a/assemblySize.include.md
+++ b/assemblySize.include.md
@@ -2,20 +2,20 @@
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |         8.0 KB |      209.5 KB | +201.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
-| netstandard2.1 |         8.5 KB |      172.0 KB | +163.5 KB |   +8.5 KB |            +6.0 KB |             +8.5 KB |    +13.5 KB |
-| net461         |         8.5 KB |      215.5 KB | +207.0 KB |   +9.5 KB |            +7.0 KB |             +9.5 KB |    +14.0 KB |
-| net462         |         7.0 KB |      214.5 KB | +207.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +14.0 KB |
-| net47          |         7.0 KB |      214.0 KB | +207.0 KB |   +9.5 KB |            +7.0 KB |             +9.5 KB |    +14.0 KB |
-| net471         |         8.5 KB |      214.5 KB | +206.0 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
-| net472         |         8.5 KB |      213.0 KB | +204.5 KB |   +9.0 KB |            +7.0 KB |             +9.0 KB |    +13.5 KB |
-| net48          |         8.5 KB |      213.0 KB | +204.5 KB |   +9.0 KB |            +7.0 KB |             +9.0 KB |    +13.5 KB |
-| net481         |         8.5 KB |      213.0 KB | +204.5 KB |   +9.0 KB |            +7.0 KB |             +9.0 KB |    +13.5 KB |
-| netcoreapp2.0  |         9.0 KB |      192.5 KB | +183.5 KB |   +9.5 KB |            +7.0 KB |             +9.0 KB |    +14.0 KB |
-| netcoreapp2.1  |         9.0 KB |      181.5 KB | +172.5 KB |  +12.0 KB |            +9.5 KB |            +12.0 KB |    +17.0 KB |
-| netcoreapp2.2  |         9.0 KB |      181.5 KB | +172.5 KB |  +12.0 KB |            +9.5 KB |            +12.0 KB |    +17.0 KB |
+| netstandard2.0 |         8.0 KB |      209.0 KB | +201.0 KB |   +9.0 KB |            +7.0 KB |             +9.5 KB |    +14.0 KB |
+| netstandard2.1 |         8.5 KB |      171.5 KB | +163.0 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +14.0 KB |
+| net461         |         8.5 KB |      215.5 KB | +207.0 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +14.0 KB |
+| net462         |         7.0 KB |      214.5 KB | +207.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
+| net47          |         7.0 KB |      214.0 KB | +207.0 KB |   +9.0 KB |            +7.0 KB |             +9.0 KB |    +14.0 KB |
+| net471         |         8.5 KB |      214.0 KB | +205.5 KB |   +9.5 KB |            +7.0 KB |             +9.5 KB |    +14.0 KB |
+| net472         |         8.5 KB |      213.0 KB | +204.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
+| net48          |         8.5 KB |      213.0 KB | +204.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
+| net481         |         8.5 KB |      213.0 KB | +204.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
+| netcoreapp2.0  |         9.0 KB |      192.5 KB | +183.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +14.0 KB |
+| netcoreapp2.1  |         9.0 KB |      181.0 KB | +172.0 KB |  +12.5 KB |           +10.0 KB |            +12.5 KB |    +17.0 KB |
+| netcoreapp2.2  |         9.0 KB |      181.0 KB | +172.0 KB |  +12.5 KB |           +10.0 KB |            +12.5 KB |    +17.0 KB |
 | netcoreapp3.0  |         9.5 KB |      177.5 KB | +168.0 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +14.0 KB |
-| netcoreapp3.1  |         9.5 KB |      176.0 KB | +166.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +13.5 KB |
+| netcoreapp3.1  |         9.5 KB |      176.0 KB | +166.5 KB |   +9.0 KB |            +6.0 KB |             +9.0 KB |    +13.5 KB |
 | net5.0         |         9.5 KB |      147.0 KB | +137.5 KB |   +9.0 KB |            +6.5 KB |             +9.0 KB |    +14.0 KB |
 | net6.0         |        10.0 KB |      108.0 KB |  +98.0 KB |  +10.0 KB |            +7.0 KB |             +1.0 KB |     +3.5 KB |
 | net7.0         |        10.0 KB |       84.0 KB |  +74.0 KB |   +9.5 KB |            +6.0 KB |             +1.0 KB |     +3.5 KB |
@@ -28,23 +28,23 @@
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |         8.0 KB |      320.9 KB | +312.9 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
-| netstandard2.1 |         8.5 KB |      264.2 KB | +255.7 KB |  +16.4 KB |            +7.7 KB |            +13.8 KB |    +19.2 KB |
-| net461         |         8.5 KB |      327.4 KB | +318.9 KB |  +17.4 KB |            +8.7 KB |            +14.8 KB |    +19.7 KB |
-| net462         |         7.0 KB |      326.4 KB | +319.4 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
-| net47          |         7.0 KB |      325.6 KB | +318.6 KB |  +17.4 KB |            +8.7 KB |            +14.8 KB |    +19.7 KB |
-| net471         |         8.5 KB |      326.1 KB | +317.6 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
-| net472         |         8.5 KB |      323.5 KB | +315.0 KB |  +16.9 KB |            +8.7 KB |            +14.3 KB |    +19.2 KB |
-| net48          |         8.5 KB |      323.5 KB | +315.0 KB |  +16.9 KB |            +8.7 KB |            +14.3 KB |    +19.2 KB |
-| net481         |         8.5 KB |      323.5 KB | +315.0 KB |  +16.9 KB |            +8.7 KB |            +14.3 KB |    +19.2 KB |
-| netcoreapp2.0  |         9.0 KB |      294.6 KB | +285.6 KB |  +17.4 KB |            +8.7 KB |            +14.3 KB |    +19.7 KB |
-| netcoreapp2.1  |         9.0 KB |      277.2 KB | +268.2 KB |  +19.9 KB |           +11.2 KB |            +17.3 KB |    +22.7 KB |
-| netcoreapp2.2  |         9.0 KB |      277.2 KB | +268.2 KB |  +19.9 KB |           +11.2 KB |            +17.3 KB |    +22.7 KB |
+| netstandard2.0 |         8.0 KB |      320.4 KB | +312.4 KB |  +16.9 KB |            +8.7 KB |            +14.8 KB |    +19.7 KB |
+| netstandard2.1 |         8.5 KB |      263.6 KB | +255.1 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
+| net461         |         8.5 KB |      327.3 KB | +318.8 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
+| net462         |         7.0 KB |      326.3 KB | +319.3 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
+| net47          |         7.0 KB |      325.6 KB | +318.6 KB |  +16.9 KB |            +8.7 KB |            +14.3 KB |    +19.7 KB |
+| net471         |         8.5 KB |      325.6 KB | +317.1 KB |  +17.4 KB |            +8.7 KB |            +14.8 KB |    +19.7 KB |
+| net472         |         8.5 KB |      323.5 KB | +315.0 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
+| net48          |         8.5 KB |      323.5 KB | +315.0 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
+| net481         |         8.5 KB |      323.5 KB | +315.0 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
+| netcoreapp2.0  |         9.0 KB |      294.6 KB | +285.6 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
+| netcoreapp2.1  |         9.0 KB |      276.7 KB | +267.7 KB |  +20.4 KB |           +11.7 KB |            +17.8 KB |    +22.7 KB |
+| netcoreapp2.2  |         9.0 KB |      276.7 KB | +267.7 KB |  +20.4 KB |           +11.7 KB |            +17.8 KB |    +22.7 KB |
 | netcoreapp3.0  |         9.5 KB |      266.3 KB | +256.8 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
-| netcoreapp3.1  |         9.5 KB |      264.8 KB | +255.3 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.2 KB |
-| net5.0         |         9.5 KB |      231.6 KB | +222.1 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
+| netcoreapp3.1  |         9.5 KB |      264.8 KB | +255.3 KB |  +16.9 KB |            +7.7 KB |            +14.3 KB |    +19.2 KB |
+| net5.0         |         9.5 KB |      231.5 KB | +222.0 KB |  +16.9 KB |            +8.2 KB |            +14.3 KB |    +19.7 KB |
 | net6.0         |        10.0 KB |      177.9 KB | +167.9 KB |  +17.9 KB |            +8.7 KB |             +2.1 KB |     +4.5 KB |
 | net7.0         |        10.0 KB |      139.6 KB | +129.6 KB |  +17.3 KB |            +7.6 KB |             +2.1 KB |     +4.5 KB |
 | net8.0         |         9.5 KB |      112.9 KB | +103.4 KB |  +16.1 KB |            +1.9 KB |             +1.6 KB |     +4.5 KB |
-| net9.0         |        10.0 KB |       65.5 KB |  +55.5 KB |  +16.6 KB |            +2.3 KB |             +2.1 KB |     +5.0 KB |
+| net9.0         |        10.0 KB |       65.4 KB |  +55.4 KB |  +16.6 KB |            +2.3 KB |             +2.1 KB |     +5.0 KB |
 | net10.0        |        10.0 KB |       48.4 KB |  +38.4 KB |  +16.6 KB |            +2.3 KB |             +2.1 KB |     +5.0 KB |

--- a/src/Polyfill/OperatingSystemCache.cs
+++ b/src/Polyfill/OperatingSystemCache.cs
@@ -104,17 +104,7 @@ static class OperatingSystemCache
     {
         if (!isAndroid.HasValue)
         {
-            try
-            {
-                isAndroid = RunProcess("uname", "-o")
-                    .Replace(" ", string.Empty)
-                    .ToLower()
-                    .Equals("android");
-            }
-            catch
-            {
-                isAndroid = false;
-            }
+            isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
         }
 
         return isAndroid.Value;

--- a/src/Split/net10.0/OperatingSystemCache.cs
+++ b/src/Split/net10.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net461/OperatingSystemCache.cs
+++ b/src/Split/net461/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net462/OperatingSystemCache.cs
+++ b/src/Split/net462/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net47/OperatingSystemCache.cs
+++ b/src/Split/net47/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net471/OperatingSystemCache.cs
+++ b/src/Split/net471/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net472/OperatingSystemCache.cs
+++ b/src/Split/net472/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net48/OperatingSystemCache.cs
+++ b/src/Split/net48/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net481/OperatingSystemCache.cs
+++ b/src/Split/net481/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net5.0/OperatingSystemCache.cs
+++ b/src/Split/net5.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net6.0/OperatingSystemCache.cs
+++ b/src/Split/net6.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net7.0/OperatingSystemCache.cs
+++ b/src/Split/net7.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net8.0/OperatingSystemCache.cs
+++ b/src/Split/net8.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net9.0/OperatingSystemCache.cs
+++ b/src/Split/net9.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp2.0/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp2.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp2.1/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp2.1/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp2.2/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp2.2/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp3.0/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp3.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp3.1/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp3.1/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netstandard2.0/OperatingSystemCache.cs
+++ b/src/Split/netstandard2.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netstandard2.1/OperatingSystemCache.cs
+++ b/src/Split/netstandard2.1/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/uap10.0/OperatingSystemCache.cs
+++ b/src/Split/uap10.0/OperatingSystemCache.cs
@@ -89,17 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			try
-			{
-				isAndroid = RunProcess("uname", "-o")
-					.Replace(" ", string.Empty)
-					.ToLower()
-					.Equals("android");
-			}
-			catch
-			{
-				isAndroid = false;
-			}
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
 		}
 		return isAndroid.Value;
 	}


### PR DESCRIPTION
Replaces the process-based detection of Android with RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android")) in OperatingSystemCache. This simplifies the logic, improves reliability, and removes the need for exception handling. Also updates assembly size documentation to reflect minor changes.