### PR TITLE
Use uppercase ANDROID for IsOSPlatform checks

### DIFF
--- a/src/Polyfill/OperatingSystemCache.cs
+++ b/src/Polyfill/OperatingSystemCache.cs
@@ -104,7 +104,7 @@ static class OperatingSystemCache
     {
         if (!isAndroid.HasValue)
         {
-            isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+            isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
         }
 
         return isAndroid.Value;

--- a/src/Split/net10.0/OperatingSystemCache.cs
+++ b/src/Split/net10.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net461/OperatingSystemCache.cs
+++ b/src/Split/net461/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net462/OperatingSystemCache.cs
+++ b/src/Split/net462/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net47/OperatingSystemCache.cs
+++ b/src/Split/net47/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net471/OperatingSystemCache.cs
+++ b/src/Split/net471/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net472/OperatingSystemCache.cs
+++ b/src/Split/net472/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net48/OperatingSystemCache.cs
+++ b/src/Split/net48/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net481/OperatingSystemCache.cs
+++ b/src/Split/net481/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net5.0/OperatingSystemCache.cs
+++ b/src/Split/net5.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net6.0/OperatingSystemCache.cs
+++ b/src/Split/net6.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net7.0/OperatingSystemCache.cs
+++ b/src/Split/net7.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net8.0/OperatingSystemCache.cs
+++ b/src/Split/net8.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/net9.0/OperatingSystemCache.cs
+++ b/src/Split/net9.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp2.0/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp2.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp2.1/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp2.1/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp2.2/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp2.2/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp3.0/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp3.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netcoreapp3.1/OperatingSystemCache.cs
+++ b/src/Split/netcoreapp3.1/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netstandard2.0/OperatingSystemCache.cs
+++ b/src/Split/netstandard2.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/netstandard2.1/OperatingSystemCache.cs
+++ b/src/Split/netstandard2.1/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Split/uap10.0/OperatingSystemCache.cs
+++ b/src/Split/uap10.0/OperatingSystemCache.cs
@@ -89,7 +89,7 @@ static class OperatingSystemCache
 	{
 		if (!isAndroid.HasValue)
 		{
-			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+			isAndroid = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 		}
 		return isAndroid.Value;
 	}

--- a/src/Tests/PolyfillTests_OperatingSystem.cs
+++ b/src/Tests/PolyfillTests_OperatingSystem.cs
@@ -65,7 +65,7 @@ partial class PolyfillTests
     public async Task IsOperatingSystemAndroid()
     {
         bool actual = OperatingSystem.IsAndroid();
-        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android"));
+        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
 
         await Assert.That(actual).IsEqualTo(expected);
     }
@@ -74,7 +74,7 @@ partial class PolyfillTests
     public async Task IsOperatingSystemTvOS()
     {
         bool actual = OperatingSystem.IsTvOS();
-        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("tvOS"));
+        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
 
         await Assert.That(actual).IsEqualTo(expected);
     }
@@ -83,7 +83,7 @@ partial class PolyfillTests
     public async Task IsOperatingSystemWatchOS()
     {
         bool actual = OperatingSystem.IsWatchOS();
-        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("watchOS"));
+        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("WATCHOS"));
 
         await Assert.That(actual).IsEqualTo(expected);
     }
@@ -92,7 +92,7 @@ partial class PolyfillTests
     public async Task IsOperatingSystemBrowser()
     {
         bool actual = OperatingSystem.IsBrowser();
-        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("Browser"));
+        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
 
         await Assert.That(actual).IsEqualTo(expected);
     }
@@ -101,7 +101,7 @@ partial class PolyfillTests
     public async Task IsOperatingSystemWasi()
     {
         bool actual = OperatingSystem.IsWasi();
-        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("wasi"));
+        bool expected = RuntimeInformation.IsOSPlatform(OSPlatform.Create("WASI"));
 
         await Assert.That(actual).IsEqualTo(expected);
     }


### PR DESCRIPTION
IsOSPlatform usually does case insensitive comparison, so casing shouldn't matter for most cases. However, on Mono, IIRC, it does case sensitive comparison. It's safer to use the uppercase form anyways which is aligned with https://github.com/dotnet/runtime/blob/73294ebb8c1bf4724e8c785e599e5ac71e06bec3/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs#L29-L30