### PR TITLE
Lower minimum System.Memory version to 4.5.4

### DIFF
--- a/src/ApiBuilderTests/AssemblySizeTest.cs
+++ b/src/ApiBuilderTests/AssemblySizeTest.cs
@@ -164,7 +164,7 @@ public class AssemblySizeTest
                           {polyOptions}
                         </PropertyGroup>
                         <ItemGroup>
-                          <PackageReference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETFramework' or $(TargetFramework.StartsWith('netcoreapp'))" Version="4.5.5" />
+                          <PackageReference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETFramework' or $(TargetFramework.StartsWith('netcoreapp'))" Version="4.5.4" />
                           <PackageReference Include="System.ValueTuple" Condition="$(TargetFramework.StartsWith('net46'))" Version="4.5.0" />
                           <PackageReference Include="System.Net.Http" Condition="$(TargetFramework.StartsWith('net4'))" Version="4.3.4" />
                           <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFrameworkIdentifier)' == '.NETFramework'" Version="4.5.4" />

--- a/src/Polyfill/Polyfill.targets
+++ b/src/Polyfill/Polyfill.targets
@@ -88,7 +88,7 @@ For example:
       <MemoryVersion>@(ResolvedCompileFileDefinitions->WithMetadataValue('NuGetPackageId', 'System.Memory')->Metadata('NuGetPackageVersion'))</MemoryVersion>
       
       <DefineConstants
-        Condition="'$(MemoryVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MemoryVersion), '4.5.5'))">$(DefineConstants);FeatureMemory</DefineConstants>
+        Condition="'$(MemoryVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MemoryVersion), '4.5.4'))">$(DefineConstants);FeatureMemory</DefineConstants>
       
       <DefineConstants
         Condition="@(ResolvedCompileFileDefinitions->AnyHaveMetadataValue('NuGetPackageId', 'System.Runtime.InteropServices.RuntimeInformation'))">$(DefineConstants);FeatureRuntimeInformation</DefineConstants>


### PR DESCRIPTION
This PR lights up features like collection expressions for projects which use System.Memory v4.5.4, which previously required at least v4.5.5.

Reasons for this change:

- API surface is the same so I don't expect this change has the potential to break anything (famous last words)
- Lowers the barrier for consumers
- System.Memory 4.5.4 is more widely transitively included than 4.5.5.
    - e.g. `System.Text.Json 6.0.x` is a popular target for .NET Standard 2.0 libraries and depends on `System.Memory 4.5.4`
- 4.5.4 remains the version with the highest download count, ensuring broad compatibility without requiring unnecessary upgrades.

<img width="903" height="1097" alt="image" src="https://github.com/user-attachments/assets/5e41d54f-1fa9-4f5a-99ad-2935f0e151aa" />
