### PR TITLE
Add warning for System.Memory version < 4.5.5

### DIFF
--- a/src/Polyfill/Polyfill.targets
+++ b/src/Polyfill/Polyfill.targets
@@ -123,7 +123,12 @@ For example:
       <DefineConstants Condition="$(LowerFramework.StartsWith('netstandard2.1'))">$(DefineConstants);FeatureMemory;FeatureValueTuple;FeatureValueTask;FeatureRuntimeInformation;FeatureCompression;FeatureAsyncInterfaces</DefineConstants>
       <DefineConstants Condition="$(LowerFramework.StartsWith('netstandard2.0'))">$(DefineConstants);FeatureValueTuple;FeatureRuntimeInformation;FeatureCompression</DefineConstants>
     </PropertyGroup>
-  
+
+    <Warning
+      Code="PolyfillMemoryVersion"
+      Text="Polyfill: System.Memory version $(MemoryVersion) is installed, but 4.5.5 or newer is required to enable FeatureMemory."
+      Condition="'$(MemoryVersion)' != '' AND !$([MSBuild]::VersionGreaterThanOrEquals($(MemoryVersion), '4.5.5'))" />
+
     <!-- The whole point of EmbeddedAttribute is to avoid the exposing the internal polyfilled APIs to consuming projects via IVT. -->
     <Error Text="PolyPublic and PolyUseEmbeddedAttribute shouldn't be used together." Condition="'$(PolyPublic)' == 'true' AND '$(PolyUseEmbeddedAttribute)' == 'true'" />
 


### PR DESCRIPTION
As discussed in #455 (wow what a coincidence on the PR number), there should be user feedback when an incompatible version of System.Memory is installed, as it can cause scenarios where newer language features fail silently (because the primitives are there but the polyfills are missing).

<img width="1904" height="1136" alt="image" src="https://github.com/user-attachments/assets/a73925b6-331f-4404-a4f3-b39c5807eca0" />

