### PR TITLE
Cache invalid path chars, remove LINQ

### DIFF
--- a/src/Polyfill/Polyfill_Compression.cs
+++ b/src/Polyfill/Polyfill_Compression.cs
@@ -2,7 +2,6 @@
 namespace Polyfills;
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
@@ -128,14 +127,15 @@ static partial class Polyfill
         }
     }
 
+    static readonly char[] invalidPathChars = Path.GetInvalidPathChars();
+
     static string SanitizeEntryFilePath(string fullName)
     {
         var sanitized = new char[fullName.Length];
         for (var index = 0; index < fullName.Length; index++)
         {
             var ch = fullName[index];
-            var chars = Path.GetInvalidPathChars();
-            if (chars.Contains(ch))
+            if (Array.IndexOf(invalidPathChars, ch) >= 0)
             {
                 sanitized[index] = '_';
                 continue;


### PR DESCRIPTION
Introduce a static readonly invalidPathChars = Path.GetInvalidPathChars() and update SanitizeEntryFilePath to check characters via Array.IndexOf instead of calling Path.GetInvalidPathChars() on each iteration and using LINQ Contains. Also remove the now-unused System.Linq using. This reduces allocations and avoids per-character calls for improved performance.