### PR TITLE
Preallocate StringBuilder with target length

### DIFF
--- a/src/Polyfill/Polyfill_String.cs
+++ b/src/Polyfill/Polyfill_String.cs
@@ -143,7 +143,7 @@ static partial class Polyfill
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string ReplaceLineEndings(this string target, string replacementText)
     {
-        var builder = new StringBuilder();
+        var builder = new StringBuilder(target.Length);
         using var reader = new StringReader(target);
         while (true)
         {


### PR DESCRIPTION
Initialize the StringBuilder in ReplaceLineEndings using target.Length to preallocate capacity. This reduces reallocations and improves performance when building the resulting string without changing behavior.