### PR TITLE
Add async ZipFile Open/OpenRead polyfills and docs

### DIFF
--- a/apiCount.include.md
+++ b/apiCount.include.md
@@ -1,1 +1,1 @@
-**API count: 738**
+**API count: 741**

--- a/api_list.include.md
+++ b/api_list.include.md
@@ -1034,6 +1034,9 @@
  * `Task ExtractToDirectoryAsync(string, string, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectoryasync?view=net-11.0)
  * `Task ExtractToDirectoryAsync(string, string, Encoding, bool, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectoryasync?view=net-11.0)
  * `Task ExtractToDirectoryAsync(string, string, Encoding, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectoryasync?view=net-11.0)
+ * `Task<ZipArchive> OpenAsync(string, ZipArchiveMode, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openasync?view=net-11.0)
+ * `Task<ZipArchive> OpenAsync(string, ZipArchiveMode, Encoding?, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openasync?view=net-11.0)
+ * `Task<ZipArchive> OpenReadAsync(string, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openreadasync?view=net-11.0)
 
 
 #### Ensure

--- a/assemblySize.include.md
+++ b/assemblySize.include.md
@@ -2,25 +2,25 @@
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       228.0KB |  +220.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netstandard2.1 |          8.5KB |       180.0KB |  +171.5KB |   +12.0KB |             +9.5KB |             +12.0KB |     +17.0KB |
-| net461         |          8.5KB |       234.5KB |  +226.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net462         |          7.0KB |       233.0KB |  +226.0KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| net47          |          7.0KB |       233.0KB |  +226.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net471         |          8.5KB |       233.0KB |  +224.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net472         |          8.5KB |       231.5KB |  +223.0KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| net48          |          8.5KB |       231.5KB |  +223.0KB |    +9.0KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| net481         |          8.5KB |       231.5KB |  +223.0KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| netcoreapp2.0  |          9.0KB |       208.5KB |  +199.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp2.1  |          9.0KB |       187.0KB |  +178.0KB |   +12.0KB |            +10.0KB |             +12.0KB |     +17.0KB |
-| netcoreapp2.2  |          9.0KB |       187.0KB |  +178.0KB |   +12.0KB |            +10.0KB |             +12.5KB |     +17.0KB |
-| netcoreapp3.0  |          9.5KB |       183.5KB |  +174.0KB |   +12.5KB |            +10.0KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.1  |          9.5KB |       182.0KB |  +172.5KB |    +9.0KB |             +9.5KB |              +9.0KB |     +14.0KB |
-| net5.0         |          9.5KB |       152.0KB |  +142.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net6.0         |         10.0KB |       112.5KB |  +102.5KB |    +9.5KB |             +7.0KB |           +512bytes |      +3.0KB |
-| net7.0         |         10.0KB |        85.0KB |   +75.0KB |    +9.5KB |             +5.5KB |           +512bytes |      +3.5KB |
-| net8.0         |          9.5KB |        68.5KB |   +59.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net9.0         |          9.5KB |        34.5KB |   +25.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
+| netstandard2.0 |          8.0KB |       228.5KB |  +220.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netstandard2.1 |          8.5KB |       180.0KB |  +171.5KB |   +12.5KB |            +10.0KB |             +12.5KB |     +17.0KB |
+| net461         |          8.5KB |       235.0KB |  +226.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net462         |          7.0KB |       233.5KB |  +226.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net47          |          7.0KB |       233.5KB |  +226.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net471         |          8.5KB |       233.5KB |  +225.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net472         |          8.5KB |       232.0KB |  +223.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net48          |          8.5KB |       232.0KB |  +223.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net481         |          8.5KB |       232.0KB |  +223.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| netcoreapp2.0  |          9.0KB |       208.5KB |  +199.5KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
+| netcoreapp2.1  |          9.0KB |       187.5KB |  +178.5KB |   +12.0KB |             +9.5KB |             +12.0KB |     +17.0KB |
+| netcoreapp2.2  |          9.0KB |       187.5KB |  +178.5KB |   +12.0KB |             +9.5KB |             +12.0KB |     +17.0KB |
+| netcoreapp3.0  |          9.5KB |       184.0KB |  +174.5KB |   +12.0KB |             +9.5KB |              +9.0KB |     +14.0KB |
+| netcoreapp3.1  |          9.5KB |       182.5KB |  +173.0KB |   +12.0KB |             +9.5KB |              +9.0KB |     +13.5KB |
+| net5.0         |          9.5KB |       152.5KB |  +143.0KB |    +9.0KB |             +6.0KB |              +9.0KB |     +13.5KB |
+| net6.0         |         10.0KB |       112.5KB |  +102.5KB |   +10.0KB |             +7.0KB |              +1.0KB |      +3.5KB |
+| net7.0         |         10.0KB |        85.5KB |   +75.5KB |    +9.5KB |             +5.5KB |           +512bytes |      +3.5KB |
+| net8.0         |          9.5KB |        69.0KB |   +59.5KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net9.0         |          9.5KB |        35.0KB |   +25.5KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 | net10.0        |         10.0KB |        22.5KB |   +12.5KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 | net11.0        |         10.0KB |        19.0KB |    +9.0KB |    +9.0KB |                    |              +1.0KB |      +4.0KB |
 
@@ -29,24 +29,24 @@
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       341.9KB |  +333.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netstandard2.1 |          8.5KB |       269.7KB |  +261.2KB |   +19.7KB |            +11.2KB |             +16.9KB |     +22.4KB |
-| net461         |          8.5KB |       348.9KB |  +340.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net462         |          7.0KB |       347.4KB |  +340.4KB |   +17.2KB |             +8.7KB |             +14.4KB |     +19.4KB |
-| net47          |          7.0KB |       347.1KB |  +340.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net471         |          8.5KB |       347.1KB |  +338.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net472         |          8.5KB |       344.5KB |  +336.0KB |   +17.2KB |             +8.7KB |             +14.4KB |     +19.4KB |
-| net48          |          8.5KB |       344.5KB |  +336.0KB |   +16.7KB |             +8.7KB |             +14.4KB |     +19.4KB |
-| net481         |          8.5KB |       344.5KB |  +336.0KB |   +17.2KB |             +8.7KB |             +14.4KB |     +19.4KB |
-| netcoreapp2.0  |          9.0KB |       312.6KB |  +303.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp2.1  |          9.0KB |       280.9KB |  +271.9KB |   +19.7KB |            +11.7KB |             +16.9KB |     +22.4KB |
-| netcoreapp2.2  |          9.0KB |       280.9KB |  +271.9KB |   +19.7KB |            +11.7KB |             +17.4KB |     +22.4KB |
-| netcoreapp3.0  |          9.5KB |       268.8KB |  +259.3KB |   +20.2KB |            +11.7KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.1  |          9.5KB |       267.3KB |  +257.8KB |   +16.7KB |            +11.2KB |             +13.9KB |     +19.4KB |
-| net5.0         |          9.5KB |       221.0KB |  +211.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net6.0         |         10.0KB |       167.1KB |  +157.1KB |   +17.2KB |             +8.7KB |              +1.1KB |      +3.7KB |
-| net7.0         |         10.0KB |       123.4KB |  +113.4KB |   +17.1KB |             +6.9KB |              +1.1KB |      +4.2KB |
-| net8.0         |          9.5KB |        97.9KB |   +88.4KB |   +16.0KB |          +299bytes |              +1.1KB |      +4.2KB |
-| net9.0         |          9.5KB |        50.5KB |   +41.0KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
+| netstandard2.0 |          8.0KB |       342.5KB |  +334.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netstandard2.1 |          8.5KB |       269.8KB |  +261.3KB |   +20.2KB |            +11.7KB |             +17.4KB |     +22.4KB |
+| net461         |          8.5KB |       349.4KB |  +340.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net462         |          7.0KB |       347.9KB |  +340.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net47          |          7.0KB |       347.7KB |  +340.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net471         |          8.5KB |       347.7KB |  +339.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net472         |          8.5KB |       345.1KB |  +336.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net48          |          8.5KB |       345.1KB |  +336.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net481         |          8.5KB |       345.1KB |  +336.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| netcoreapp2.0  |          9.0KB |       312.7KB |  +303.7KB |   +17.2KB |             +8.7KB |             +14.4KB |     +19.4KB |
+| netcoreapp2.1  |          9.0KB |       281.5KB |  +272.5KB |   +19.7KB |            +11.2KB |             +16.9KB |     +22.4KB |
+| netcoreapp2.2  |          9.0KB |       281.5KB |  +272.5KB |   +19.7KB |            +11.2KB |             +16.9KB |     +22.4KB |
+| netcoreapp3.0  |          9.5KB |       269.4KB |  +259.9KB |   +19.7KB |            +11.2KB |             +13.9KB |     +19.4KB |
+| netcoreapp3.1  |          9.5KB |       267.9KB |  +258.4KB |   +19.7KB |            +11.2KB |             +13.9KB |     +18.9KB |
+| net5.0         |          9.5KB |       221.6KB |  +212.1KB |   +16.7KB |             +7.7KB |             +13.9KB |     +18.9KB |
+| net6.0         |         10.0KB |       167.2KB |  +157.2KB |   +17.7KB |             +8.7KB |              +1.6KB |      +4.2KB |
+| net7.0         |         10.0KB |       124.0KB |  +114.0KB |   +17.1KB |             +6.9KB |              +1.1KB |      +4.2KB |
+| net8.0         |          9.5KB |        98.5KB |   +89.0KB |   +16.0KB |          +299bytes |              +1.1KB |      +4.2KB |
+| net9.0         |          9.5KB |        51.0KB |   +41.5KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
 | net10.0        |         10.0KB |        33.9KB |   +23.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
 | net11.0        |         10.0KB |        28.5KB |   +18.5KB |   +16.5KB |                    |              +1.6KB |      +4.7KB |

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The package targets `netstandard2.0` and is designed to support the following ru
  * `uap10`
 
 
-**API count: 738**<!-- singleLineInclude: apiCount. path: /apiCount.include.md -->
+**API count: 741**<!-- singleLineInclude: apiCount. path: /apiCount.include.md -->
 
 
 **See [Milestones](../../milestones?state=closed) for release notes.**
@@ -68,25 +68,25 @@ This project uses features from the current stable SDK and C# language. As such 
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       228.0KB |  +220.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netstandard2.1 |          8.5KB |       180.0KB |  +171.5KB |   +12.0KB |             +9.5KB |             +12.0KB |     +17.0KB |
-| net461         |          8.5KB |       234.5KB |  +226.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net462         |          7.0KB |       233.0KB |  +226.0KB |    +9.0KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| net47          |          7.0KB |       233.0KB |  +226.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net471         |          8.5KB |       233.0KB |  +224.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net472         |          8.5KB |       231.5KB |  +223.0KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| net48          |          8.5KB |       231.5KB |  +223.0KB |    +9.0KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| net481         |          8.5KB |       231.5KB |  +223.0KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
-| netcoreapp2.0  |          9.0KB |       208.5KB |  +199.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp2.1  |          9.0KB |       187.0KB |  +178.0KB |   +12.0KB |            +10.0KB |             +12.0KB |     +17.0KB |
-| netcoreapp2.2  |          9.0KB |       187.0KB |  +178.0KB |   +12.0KB |            +10.0KB |             +12.5KB |     +17.0KB |
-| netcoreapp3.0  |          9.5KB |       183.5KB |  +174.0KB |   +12.5KB |            +10.0KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.1  |          9.5KB |       182.0KB |  +172.5KB |    +9.0KB |             +9.5KB |              +9.0KB |     +14.0KB |
-| net5.0         |          9.5KB |       152.0KB |  +142.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net6.0         |         10.0KB |       112.5KB |  +102.5KB |    +9.5KB |             +7.0KB |           +512bytes |      +3.0KB |
-| net7.0         |         10.0KB |        85.0KB |   +75.0KB |    +9.5KB |             +5.5KB |           +512bytes |      +3.5KB |
-| net8.0         |          9.5KB |        68.5KB |   +59.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net9.0         |          9.5KB |        34.5KB |   +25.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
+| netstandard2.0 |          8.0KB |       228.5KB |  +220.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netstandard2.1 |          8.5KB |       180.0KB |  +171.5KB |   +12.5KB |            +10.0KB |             +12.5KB |     +17.0KB |
+| net461         |          8.5KB |       235.0KB |  +226.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net462         |          7.0KB |       233.5KB |  +226.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net47          |          7.0KB |       233.5KB |  +226.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net471         |          8.5KB |       233.5KB |  +225.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net472         |          8.5KB |       232.0KB |  +223.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net48          |          8.5KB |       232.0KB |  +223.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net481         |          8.5KB |       232.0KB |  +223.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| netcoreapp2.0  |          9.0KB |       208.5KB |  +199.5KB |    +9.5KB |             +7.0KB |              +9.5KB |     +14.0KB |
+| netcoreapp2.1  |          9.0KB |       187.5KB |  +178.5KB |   +12.0KB |             +9.5KB |             +12.0KB |     +17.0KB |
+| netcoreapp2.2  |          9.0KB |       187.5KB |  +178.5KB |   +12.0KB |             +9.5KB |             +12.0KB |     +17.0KB |
+| netcoreapp3.0  |          9.5KB |       184.0KB |  +174.5KB |   +12.0KB |             +9.5KB |              +9.0KB |     +14.0KB |
+| netcoreapp3.1  |          9.5KB |       182.5KB |  +173.0KB |   +12.0KB |             +9.5KB |              +9.0KB |     +13.5KB |
+| net5.0         |          9.5KB |       152.5KB |  +143.0KB |    +9.0KB |             +6.0KB |              +9.0KB |     +13.5KB |
+| net6.0         |         10.0KB |       112.5KB |  +102.5KB |   +10.0KB |             +7.0KB |              +1.0KB |      +3.5KB |
+| net7.0         |         10.0KB |        85.5KB |   +75.5KB |    +9.5KB |             +5.5KB |           +512bytes |      +3.5KB |
+| net8.0         |          9.5KB |        69.0KB |   +59.5KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net9.0         |          9.5KB |        35.0KB |   +25.5KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 | net10.0        |         10.0KB |        22.5KB |   +12.5KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 | net11.0        |         10.0KB |        19.0KB |    +9.0KB |    +9.0KB |                    |              +1.0KB |      +4.0KB |
 
@@ -95,27 +95,27 @@ This project uses features from the current stable SDK and C# language. As such 
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       344.3KB |  +336.3KB |   +16.7KB |             +8.2KB |             +14.0KB |     +19.7KB |
-| netstandard2.1 |          8.5KB |       271.4KB |  +262.9KB |   +19.7KB |            +11.2KB |             +17.0KB |     +22.7KB |
-| net461         |          8.5KB |       351.3KB |  +342.8KB |   +16.7KB |             +8.2KB |             +14.0KB |     +19.7KB |
-| net462         |          7.0KB |       349.8KB |  +342.8KB |   +16.7KB |             +8.7KB |             +14.5KB |     +19.7KB |
-| net47          |          7.0KB |       349.5KB |  +342.5KB |   +16.7KB |             +8.2KB |             +14.0KB |     +19.7KB |
-| net471         |          8.5KB |       349.5KB |  +341.0KB |   +16.7KB |             +8.2KB |             +14.0KB |     +19.7KB |
-| net472         |          8.5KB |       346.9KB |  +338.4KB |   +17.2KB |             +8.7KB |             +14.5KB |     +19.7KB |
-| net48          |          8.5KB |       346.9KB |  +338.4KB |   +16.7KB |             +8.7KB |             +14.5KB |     +19.7KB |
-| net481         |          8.5KB |       346.9KB |  +338.4KB |   +17.2KB |             +8.7KB |             +14.5KB |     +19.7KB |
-| netcoreapp2.0  |          9.0KB |       314.8KB |  +305.8KB |   +16.7KB |             +8.2KB |             +14.0KB |     +19.2KB |
-| netcoreapp2.1  |          9.0KB |       282.9KB |  +273.9KB |   +19.7KB |            +11.7KB |             +17.0KB |     +22.7KB |
-| netcoreapp2.2  |          9.0KB |       282.9KB |  +273.9KB |   +19.7KB |            +11.7KB |             +17.5KB |     +22.7KB |
-| netcoreapp3.0  |          9.5KB |       270.5KB |  +261.0KB |   +20.2KB |            +11.7KB |             +14.0KB |     +19.7KB |
-| netcoreapp3.1  |          9.5KB |       268.9KB |  +259.4KB |   +16.7KB |            +11.2KB |             +14.0KB |     +19.7KB |
-| net5.0         |          9.5KB |       222.7KB |  +213.2KB |   +16.7KB |             +8.2KB |             +14.0KB |     +19.7KB |
-| net6.0         |         10.0KB |       168.3KB |  +158.3KB |   +17.2KB |             +8.7KB |              +1.1KB |      +3.7KB |
-| net7.0         |         10.0KB |       124.3KB |  +114.3KB |   +17.1KB |             +6.9KB |              +1.1KB |      +4.2KB |
-| net8.0         |          9.5KB |        98.7KB |   +89.2KB |   +16.0KB |          +299bytes |              +1.1KB |      +4.2KB |
-| net9.0         |          9.5KB |        50.9KB |   +41.4KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
-| net10.0        |         10.0KB |        34.1KB |   +24.1KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
-| net11.0        |         10.0KB |        28.7KB |   +18.7KB |   +16.5KB |                    |              +1.6KB |      +4.7KB |
+| netstandard2.0 |          8.0KB |       342.5KB |  +334.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netstandard2.1 |          8.5KB |       269.8KB |  +261.3KB |   +20.2KB |            +11.7KB |             +17.4KB |     +22.4KB |
+| net461         |          8.5KB |       349.4KB |  +340.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net462         |          7.0KB |       347.9KB |  +340.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net47          |          7.0KB |       347.7KB |  +340.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net471         |          8.5KB |       347.7KB |  +339.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net472         |          8.5KB |       345.1KB |  +336.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net48          |          8.5KB |       345.1KB |  +336.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net481         |          8.5KB |       345.1KB |  +336.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| netcoreapp2.0  |          9.0KB |       312.7KB |  +303.7KB |   +17.2KB |             +8.7KB |             +14.4KB |     +19.4KB |
+| netcoreapp2.1  |          9.0KB |       281.5KB |  +272.5KB |   +19.7KB |            +11.2KB |             +16.9KB |     +22.4KB |
+| netcoreapp2.2  |          9.0KB |       281.5KB |  +272.5KB |   +19.7KB |            +11.2KB |             +16.9KB |     +22.4KB |
+| netcoreapp3.0  |          9.5KB |       269.4KB |  +259.9KB |   +19.7KB |            +11.2KB |             +13.9KB |     +19.4KB |
+| netcoreapp3.1  |          9.5KB |       267.9KB |  +258.4KB |   +19.7KB |            +11.2KB |             +13.9KB |     +18.9KB |
+| net5.0         |          9.5KB |       221.6KB |  +212.1KB |   +16.7KB |             +7.7KB |             +13.9KB |     +18.9KB |
+| net6.0         |         10.0KB |       167.2KB |  +157.2KB |   +17.7KB |             +8.7KB |              +1.6KB |      +4.2KB |
+| net7.0         |         10.0KB |       124.0KB |  +114.0KB |   +17.1KB |             +6.9KB |              +1.1KB |      +4.2KB |
+| net8.0         |          9.5KB |        98.5KB |   +89.0KB |   +16.0KB |          +299bytes |              +1.1KB |      +4.2KB |
+| net9.0         |          9.5KB |        51.0KB |   +41.5KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
+| net10.0        |         10.0KB |        33.9KB |   +23.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
+| net11.0        |         10.0KB |        28.5KB |   +18.5KB |   +16.5KB |                    |              +1.6KB |      +4.7KB |
 <!-- endInclude -->
 
 
@@ -1537,6 +1537,9 @@ The class `Polyfill` includes the following extension methods:
  * `Task ExtractToDirectoryAsync(string, string, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectoryasync?view=net-11.0)
  * `Task ExtractToDirectoryAsync(string, string, Encoding, bool, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectoryasync?view=net-11.0)
  * `Task ExtractToDirectoryAsync(string, string, Encoding, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectoryasync?view=net-11.0)
+ * `Task<ZipArchive> OpenAsync(string, ZipArchiveMode, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openasync?view=net-11.0)
+ * `Task<ZipArchive> OpenAsync(string, ZipArchiveMode, Encoding?, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openasync?view=net-11.0)
+ * `Task<ZipArchive> OpenReadAsync(string, CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openreadasync?view=net-11.0)
 
 
 #### Ensure

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -1248,6 +1248,14 @@ class Consume
         await ZipFile.CreateFromDirectoryAsync("source", "archive.zip", CompressionLevel.Optimal, includeBaseDirectory: false, CancellationToken.None);
         await ZipFile.CreateFromDirectoryAsync("source", "archive.zip", CompressionLevel.Optimal, includeBaseDirectory: false, Encoding.UTF8);
         await ZipFile.CreateFromDirectoryAsync("source", "archive.zip", CompressionLevel.Optimal, includeBaseDirectory: false, Encoding.UTF8, CancellationToken.None);
+
+        await ZipFile.OpenAsync("archive.zip", ZipArchiveMode.Read);
+        await ZipFile.OpenAsync("archive.zip", ZipArchiveMode.Read, CancellationToken.None);
+        await ZipFile.OpenAsync("archive.zip", ZipArchiveMode.Read, Encoding.UTF8);
+        await ZipFile.OpenAsync("archive.zip", ZipArchiveMode.Read, Encoding.UTF8, CancellationToken.None);
+
+        await ZipFile.OpenReadAsync("archive.zip");
+        await ZipFile.OpenReadAsync("archive.zip", CancellationToken.None);
     }
 #endif
 }

--- a/src/Polyfill/ZipFilePolyfill.cs
+++ b/src/Polyfill/ZipFilePolyfill.cs
@@ -92,6 +92,37 @@ static partial class Polyfill
         }
 
         /// <summary>
+        /// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openasync?view=net-11.0
+        public static Task<ZipArchive> OpenAsync(
+            string archiveFileName,
+            ZipArchiveMode mode,
+            CancellationToken cancellationToken = default) =>
+            Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+
+        /// <summary>
+        /// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openasync?view=net-11.0
+        public static Task<ZipArchive> OpenAsync(
+            string archiveFileName,
+            ZipArchiveMode mode,
+            Encoding? entryNameEncoding,
+            CancellationToken cancellationToken = default) =>
+            Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+
+        /// <summary>
+        /// Asynchronously opens a ZipArchive on the specified path for reading.
+        /// The specified file is opened with FileMode.Open.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.openreadasync?view=net-11.0
+        public static Task<ZipArchive> OpenReadAsync(
+            string archiveFileName,
+            CancellationToken cancellationToken = default) =>
+            Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+
+        /// <summary>
         /// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
         /// </summary>
         //Link: https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.createfromdirectoryasync?view=net-11.0

--- a/src/Split/net461/ZipFilePolyfill.cs
+++ b/src/Split/net461/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net462/ZipFilePolyfill.cs
+++ b/src/Split/net462/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net47/ZipFilePolyfill.cs
+++ b/src/Split/net47/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net471/ZipFilePolyfill.cs
+++ b/src/Split/net471/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net472/ZipFilePolyfill.cs
+++ b/src/Split/net472/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net48/ZipFilePolyfill.cs
+++ b/src/Split/net48/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net481/ZipFilePolyfill.cs
+++ b/src/Split/net481/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net5.0/ZipFilePolyfill.cs
+++ b/src/Split/net5.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net6.0/ZipFilePolyfill.cs
+++ b/src/Split/net6.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net7.0/ZipFilePolyfill.cs
+++ b/src/Split/net7.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net8.0/ZipFilePolyfill.cs
+++ b/src/Split/net8.0/ZipFilePolyfill.cs
@@ -64,6 +64,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding, overwrite);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/net9.0/ZipFilePolyfill.cs
+++ b/src/Split/net9.0/ZipFilePolyfill.cs
@@ -64,6 +64,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding, overwrite);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netcoreapp2.0/ZipFilePolyfill.cs
+++ b/src/Split/netcoreapp2.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netcoreapp2.1/ZipFilePolyfill.cs
+++ b/src/Split/netcoreapp2.1/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netcoreapp2.2/ZipFilePolyfill.cs
+++ b/src/Split/netcoreapp2.2/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netcoreapp3.0/ZipFilePolyfill.cs
+++ b/src/Split/netcoreapp3.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netcoreapp3.1/ZipFilePolyfill.cs
+++ b/src/Split/netcoreapp3.1/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netstandard2.0/ZipFilePolyfill.cs
+++ b/src/Split/netstandard2.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/netstandard2.1/ZipFilePolyfill.cs
+++ b/src/Split/netstandard2.1/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(

--- a/src/Split/uap10.0/ZipFilePolyfill.cs
+++ b/src/Split/uap10.0/ZipFilePolyfill.cs
@@ -72,6 +72,31 @@ static partial class Polyfill
 			ZipFile.ExtractToDirectory(sourceArchiveFile, destinationDirectory, encoding);
 		}
 		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified archiveFileName in the specified ZipArchiveMode mode.
+		/// </summary>
+		public static Task<ZipArchive> OpenAsync(
+			string archiveFileName,
+			ZipArchiveMode mode,
+			Encoding? entryNameEncoding,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.Open(archiveFileName, mode, entryNameEncoding), cancellationToken);
+		/// <summary>
+		/// Asynchronously opens a ZipArchive on the specified path for reading.
+		/// The specified file is opened with FileMode.Open.
+		/// </summary>
+		public static Task<ZipArchive> OpenReadAsync(
+			string archiveFileName,
+			CancellationToken cancellationToken = default) =>
+			Task.Run(() => ZipFile.OpenRead(archiveFileName), cancellationToken);
+		/// <summary>
 		/// Asynchronously creates a zip archive that contains the files and directories from the specified directory.
 		/// </summary>
 		public static Task CreateFromDirectoryAsync(


### PR DESCRIPTION
Introduce async polyfills for ZipFile.Open and ZipFile.OpenRead (OpenAsync overloads and OpenReadAsync) across the main Polyfill and per-target split files. Update the Consume sample to exercise the new async APIs. Refresh documentation and metadata: api_list.include.md, apiCount.include.md (API count +3), readme.md, and assemblySize.include.md to reflect the new APIs and size changes.