### PR TITLE
Add GC.AllocateUninitializedArray<T> polyfill

### DIFF
--- a/api_list.include.md
+++ b/api_list.include.md
@@ -370,6 +370,11 @@
  * `void SetUnixFileMode(string, UnixFileMode)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.setunixfilemode?view=net-11.0#system-io-file-setunixfilemode(system-string-system-io-unixfilemode))
 
 
+#### GC
+
+ * `T[] AllocateUninitializedArray<T>(int, bool)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0)
+
+
 #### Guid
 
  * `bool TryFormat(Span<byte>, int, ReadOnlySpan<char>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.guid.tryformat?view=net-11.0#system-guid-tryformat(system-span((system-byte))-system-int32@-system-readonlyspan((system-char))))

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ This project uses features from the current stable SDK and C# language. As such 
 | net5.0         |          9.5KB |       208.0KB |  +198.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
 | net6.0         |         10.0KB |       152.0KB |  +142.0KB |   +10.0KB |             +7.0KB |           +512bytes |      +4.0KB |
 | net7.0         |         10.0KB |       117.5KB |  +107.5KB |    +9.0KB |             +5.5KB |           +512bytes |      +4.0KB |
-| net8.0         |          9.5KB |        89.0KB |   +79.5KB |    +8.5KB |          +512bytes |              +1.0KB |      +3.5KB |
+| net8.0         |          9.5KB |        89.0KB |   +79.5KB |    +9.0KB |          +512bytes |              +1.0KB |      +3.5KB |
 | net9.0         |          9.5KB |        47.0KB |   +37.5KB |    +9.0KB |                    |              +1.0KB |      +3.5KB |
 | net10.0        |         10.0KB |        23.5KB |   +13.5KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 | net11.0        |         10.0KB |        18.5KB |    +8.5KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
@@ -124,23 +124,23 @@ This project uses features from the current stable SDK and C# language. As such 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
 | netstandard2.0 |          8.0KB |       436.4KB |  +428.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netstandard2.1 |          8.5KB |       363.0KB |  +354.5KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| net461         |          8.5KB |       434.4KB |  +425.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net462         |          7.0KB |       437.9KB |  +430.9KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netstandard2.1 |          8.5KB |       362.9KB |  +354.4KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| net461         |          8.5KB |       434.3KB |  +425.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net462         |          7.0KB |       437.8KB |  +430.8KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
 | net47          |          7.0KB |       437.6KB |  +430.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
 | net471         |          8.5KB |       437.6KB |  +429.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
 | net472         |          8.5KB |       435.0KB |  +426.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
 | net48          |          8.5KB |       435.0KB |  +426.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
 | net481         |          8.5KB |       435.0KB |  +426.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
 | netcoreapp2.0  |          9.0KB |       402.3KB |  +393.3KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp2.1  |          9.0KB |       370.2KB |  +361.2KB |   +16.7KB |             +8.7KB |             +14.4KB |     +19.4KB |
-| netcoreapp2.2  |          9.0KB |       370.2KB |  +361.2KB |   +16.7KB |             +8.7KB |             +14.4KB |     +19.4KB |
-| netcoreapp3.0  |          9.5KB |       351.9KB |  +342.4KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netcoreapp2.1  |          9.0KB |       370.1KB |  +361.1KB |   +16.7KB |             +8.7KB |             +14.4KB |     +19.4KB |
+| netcoreapp2.2  |          9.0KB |       370.1KB |  +361.1KB |   +16.7KB |             +8.7KB |             +14.4KB |     +19.4KB |
+| netcoreapp3.0  |          9.5KB |       351.8KB |  +342.3KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
 | netcoreapp3.1  |          9.5KB |       350.3KB |  +340.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net5.0         |          9.5KB |       297.2KB |  +287.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net6.0         |         10.0KB |       223.5KB |  +213.5KB |   +17.7KB |             +8.7KB |              +1.1KB |      +4.7KB |
+| net5.0         |          9.5KB |       297.2KB |  +287.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net6.0         |         10.0KB |       223.4KB |  +213.4KB |   +17.7KB |             +8.7KB |              +1.1KB |      +4.7KB |
 | net7.0         |         10.0KB |       170.2KB |  +160.2KB |   +16.6KB |             +6.9KB |              +1.1KB |      +4.7KB |
-| net8.0         |          9.5KB |       126.8KB |  +117.3KB |   +16.0KB |          +811bytes |              +1.6KB |      +4.2KB |
+| net8.0         |          9.5KB |       126.8KB |  +117.3KB |   +16.5KB |          +811bytes |              +1.6KB |      +4.2KB |
 | net9.0         |          9.5KB |        67.8KB |   +58.3KB |   +16.5KB |                    |              +1.6KB |      +4.2KB |
 | net10.0        |         10.0KB |        35.8KB |   +25.8KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
 | net11.0        |         10.0KB |        27.4KB |   +17.4KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
@@ -899,6 +899,11 @@ The class `Polyfill` includes the following extension methods:
 
  * `UnixFileMode GetUnixFileMode(string)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.getunixfilemode?view=net-11.0#system-io-file-getunixfilemode(system-string))
  * `void SetUnixFileMode(string, UnixFileMode)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.setunixfilemode?view=net-11.0#system-io-file-setunixfilemode(system-string-system-io-unixfilemode))
+
+
+#### GC
+
+ * `T[] AllocateUninitializedArray<T>(int, bool)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0)
 
 
 #### Guid

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -795,6 +795,12 @@ class Consume
         using var stderr = Console.OpenStandardErrorHandle();
     }
 
+    void GC_Methods()
+    {
+        var array = GC.AllocateUninitializedArray<int>(10);
+        var pinnedArray = GC.AllocateUninitializedArray<byte>(5, pinned: true);
+    }
+
     void File_Methods()
     {
         const string TestFilePath = "testfile.txt";

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -798,7 +798,6 @@ class Consume
     void GC_Methods()
     {
         var array = GC.AllocateUninitializedArray<int>(10);
-        var pinnedArray = GC.AllocateUninitializedArray<byte>(5, pinned: true);
     }
 
     void File_Methods()

--- a/src/Polyfill/GCPolyfill.cs
+++ b/src/Polyfill/GCPolyfill.cs
@@ -14,9 +14,15 @@ static partial class Polyfill
         /// with newer APIs. On older runtimes the returned array is zero-initialized.
         /// </summary>
         //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
-            new T[length];
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false)
+        {
+            if (pinned)
+            {
+                throw new NotSupportedException("Pinned allocations are not supported on this runtime.");
+            }
+
+            return new T[length];
+        }
 
     }
 }

--- a/src/Polyfill/GCPolyfill.cs
+++ b/src/Polyfill/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net10.0/GCPolyfill.cs
+++ b/src/Split/net10.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net11.0/GCPolyfill.cs
+++ b/src/Split/net11.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net461/GCPolyfill.cs
+++ b/src/Split/net461/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net462/GCPolyfill.cs
+++ b/src/Split/net462/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net47/GCPolyfill.cs
+++ b/src/Split/net47/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net471/GCPolyfill.cs
+++ b/src/Split/net471/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net472/GCPolyfill.cs
+++ b/src/Split/net472/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net48/GCPolyfill.cs
+++ b/src/Split/net48/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net481/GCPolyfill.cs
+++ b/src/Split/net481/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net5.0/GCPolyfill.cs
+++ b/src/Split/net5.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net6.0/GCPolyfill.cs
+++ b/src/Split/net6.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net7.0/GCPolyfill.cs
+++ b/src/Split/net7.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net8.0/GCPolyfill.cs
+++ b/src/Split/net8.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/net9.0/GCPolyfill.cs
+++ b/src/Split/net9.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netcoreapp2.0/GCPolyfill.cs
+++ b/src/Split/netcoreapp2.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netcoreapp2.1/GCPolyfill.cs
+++ b/src/Split/netcoreapp2.1/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netcoreapp2.2/GCPolyfill.cs
+++ b/src/Split/netcoreapp2.2/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netcoreapp3.0/GCPolyfill.cs
+++ b/src/Split/netcoreapp3.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netcoreapp3.1/GCPolyfill.cs
+++ b/src/Split/netcoreapp3.1/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netstandard2.0/GCPolyfill.cs
+++ b/src/Split/netstandard2.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/netstandard2.1/GCPolyfill.cs
+++ b/src/Split/netstandard2.1/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Split/uap10.0/GCPolyfill.cs
+++ b/src/Split/uap10.0/GCPolyfill.cs
@@ -1,0 +1,23 @@
+#if !NET5_0_OR_GREATER
+
+namespace Polyfills;
+
+using System;
+using System.Runtime.CompilerServices;
+
+static partial class Polyfill
+{
+    extension(GC)
+    {
+        /// <summary>
+        /// Allocates an array of a specified type and length. Provides source-level compatibility
+        /// with newer APIs. On older runtimes the returned array is zero-initialized.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.gc.allocateuninitializedarray?view=net-11.0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) =>
+            new T[length];
+
+    }
+}
+#endif

--- a/src/Tests/GCPolyfillTests.cs
+++ b/src/Tests/GCPolyfillTests.cs
@@ -10,8 +10,13 @@ public class GCPolyfillTests
     [Test]
     public async Task AllocateUninitializedArrayPinned()
     {
+#if NET5_0_OR_GREATER
         var array = GC.AllocateUninitializedArray<byte>(5, pinned: true);
         await Assert.That(array.Length).IsEqualTo(5);
+#else
+        await Assert.That(() => GC.AllocateUninitializedArray<byte>(5, pinned: true))
+            .Throws<NotSupportedException>();
+#endif
     }
 
     [Test]

--- a/src/Tests/GCPolyfillTests.cs
+++ b/src/Tests/GCPolyfillTests.cs
@@ -1,0 +1,23 @@
+public class GCPolyfillTests
+{
+    [Test]
+    public async Task AllocateUninitializedArray()
+    {
+        var array = GC.AllocateUninitializedArray<int>(10);
+        await Assert.That(array.Length).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task AllocateUninitializedArrayPinned()
+    {
+        var array = GC.AllocateUninitializedArray<byte>(5, pinned: true);
+        await Assert.That(array.Length).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task AllocateUninitializedArrayEmpty()
+    {
+        var array = GC.AllocateUninitializedArray<double>(0);
+        await Assert.That(array.Length).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Summary

Add source-compatible polyfill for GC.AllocateUninitializedArray<T>(int, bool) which was introduced in .NET 5.0.

On older runtimes the implementation delegates to 
ew T[length] (zero-initialized) for **source compliance** — code that calls this API compiles and runs correctly on all targets, though without the performance benefit of skipping zero-initialization.

### Guard

#if !NET5_0_OR_GREATER — the native API exists from .NET 5.0 onward.

## Changes

- **src/Polyfill/GCPolyfill.cs** — Canonical polyfill implementation
- **src/Tests/GCPolyfillTests.cs** — TUnit tests
- **src/Consume/Consume.cs** — Compile-time consume coverage
- **api_list.include.md** — Updated API list
- **src/Split/{tfm}/GCPolyfill.cs** — Per-TFM split copies