### PR TITLE
Fix NET 8 CreateVersion7 polyfill RFC 9562/IETF variant bits

### DIFF
--- a/src/Polyfill/GuidPolyfill.cs
+++ b/src/Polyfill/GuidPolyfill.cs
@@ -60,6 +60,9 @@ static partial class Polyfill
             uuidBytes[6] &= 0x0F;
             uuidBytes[6] += 0x70;
 
+            uuidBytes[8] &= 0x3F;
+            uuidBytes[8] += 0x80;
+
             return new(uuidBytes, true);
 
 #else


### PR DESCRIPTION
Set correct UUID variant bits in uuidBytes array

Updated manipulation of the 9th byte in uuidBytes to mask with 0x3F and set the two highest bits to '10', ensuring compliance with the UUID variant specification.

This matches the same task done in in the non NET8 code.