### PR TITLE
Fix encoding span polyfills for empty spans

### DIFF
--- a/assemblySize.include.md
+++ b/assemblySize.include.md
@@ -8,8 +8,8 @@
 | net462         |          7.0KB |       356.5KB |  +349.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | net47          |          7.0KB |       356.5KB |  +349.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | net471         |          8.5KB |       355.5KB |  +347.0KB |    +7.5KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net472         |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net48          |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net472         |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
+| net48          |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | net481         |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
 | netcoreapp2.0  |          9.0KB |       331.5KB |  +322.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp2.1  |          9.0KB |       311.5KB |  +302.5KB |    +8.5KB |             +6.0KB |              +9.0KB |     +13.5KB |
@@ -29,16 +29,16 @@
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       517.3KB |  +509.3KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| netstandard2.1 |          8.5KB |       444.2KB |  +435.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net461         |          8.5KB |       517.4KB |  +508.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net462         |          7.0KB |       520.9KB |  +513.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net47          |          7.0KB |       520.6KB |  +513.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net471         |          8.5KB |       519.3KB |  +510.8KB |   +15.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net472         |          8.5KB |       516.7KB |  +508.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net48          |          8.5KB |       516.7KB |  +508.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net481         |          8.5KB |       516.7KB |  +508.2KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| netcoreapp2.0  |          9.0KB |       484.2KB |  +475.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netstandard2.0 |          8.0KB |       517.5KB |  +509.5KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netstandard2.1 |          8.5KB |       444.3KB |  +435.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net461         |          8.5KB |       517.6KB |  +509.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net462         |          7.0KB |       521.1KB |  +514.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net47          |          7.0KB |       520.8KB |  +513.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net471         |          8.5KB |       519.5KB |  +511.0KB |   +15.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net472         |          8.5KB |       516.9KB |  +508.4KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| net48          |          8.5KB |       516.9KB |  +508.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net481         |          8.5KB |       516.9KB |  +508.4KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netcoreapp2.0  |          9.0KB |       484.4KB |  +475.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.1  |          9.0KB |       452.0KB |  +443.0KB |   +16.2KB |             +7.7KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.2  |          9.0KB |       452.0KB |  +443.0KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp3.0  |          9.5KB |       435.7KB |  +426.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |

--- a/readme.md
+++ b/readme.md
@@ -102,8 +102,8 @@ This project uses features from the newest stable SDK and C# language. As such c
 | net462         |          7.0KB |       356.5KB |  +349.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | net47          |          7.0KB |       356.5KB |  +349.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | net471         |          8.5KB |       355.5KB |  +347.0KB |    +7.5KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net472         |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| net48          |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net472         |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
+| net48          |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | net481         |          8.5KB |       354.0KB |  +345.5KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
 | netcoreapp2.0  |          9.0KB |       331.5KB |  +322.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp2.1  |          9.0KB |       311.5KB |  +302.5KB |    +8.5KB |             +6.0KB |              +9.0KB |     +13.5KB |
@@ -123,16 +123,16 @@ This project uses features from the newest stable SDK and C# language. As such c
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       517.3KB |  +509.3KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| netstandard2.1 |          8.5KB |       444.2KB |  +435.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net461         |          8.5KB |       517.4KB |  +508.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net462         |          7.0KB |       520.9KB |  +513.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net47          |          7.0KB |       520.6KB |  +513.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net471         |          8.5KB |       519.3KB |  +510.8KB |   +15.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net472         |          8.5KB |       516.7KB |  +508.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net48          |          8.5KB |       516.7KB |  +508.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| net481         |          8.5KB |       516.7KB |  +508.2KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| netcoreapp2.0  |          9.0KB |       484.2KB |  +475.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netstandard2.0 |          8.0KB |       517.5KB |  +509.5KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netstandard2.1 |          8.5KB |       444.3KB |  +435.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net461         |          8.5KB |       517.6KB |  +509.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net462         |          7.0KB |       521.1KB |  +514.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net47          |          7.0KB |       520.8KB |  +513.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net471         |          8.5KB |       519.5KB |  +511.0KB |   +15.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net472         |          8.5KB |       516.9KB |  +508.4KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| net48          |          8.5KB |       516.9KB |  +508.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net481         |          8.5KB |       516.9KB |  +508.4KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netcoreapp2.0  |          9.0KB |       484.4KB |  +475.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.1  |          9.0KB |       452.0KB |  +443.0KB |   +16.2KB |             +7.7KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.2  |          9.0KB |       452.0KB |  +443.0KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp3.0  |          9.5KB |       435.7KB |  +426.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |

--- a/src/Polyfill/Polyfill_Encoder.cs
+++ b/src/Polyfill/Polyfill_Encoder.cs
@@ -15,8 +15,20 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
     public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
     {
-        fixed (char* charsPtr = chars)
-        fixed (byte* bytesPtr = bytes)
+        var charsToPin = chars;
+        if (charsToPin.IsEmpty)
+        {
+            charsToPin = stackalloc char[1];
+        }
+
+        var bytesToPin = bytes;
+        if (bytesToPin.IsEmpty)
+        {
+            bytesToPin = stackalloc byte[1];
+        }
+
+        fixed (char* charsPtr = charsToPin)
+        fixed (byte* bytesPtr = bytesToPin)
         {
             target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
         }

--- a/src/Polyfill/Polyfill_Encoding.cs
+++ b/src/Polyfill/Polyfill_Encoding.cs
@@ -14,8 +14,19 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
     public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
     {
+        if (chars.IsEmpty)
+        {
+            return 0;
+        }
+
+        var bytesToPin = bytes;
+        if (bytesToPin.IsEmpty)
+        {
+            bytesToPin = stackalloc byte[1];
+        }
+
         fixed (char* charsPtr = chars)
-        fixed (byte* bytesPtr = bytes)
+        fixed (byte* bytesPtr = bytesToPin)
         {
             return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
         }
@@ -35,6 +46,11 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
     public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
     {
+        if (bytes.IsEmpty)
+        {
+            return string.Empty;
+        }
+
         fixed (byte* bytesPtr = bytes)
         {
             return target.GetString(bytesPtr, bytes.Length);

--- a/src/Polyfill/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Polyfill/Polyfill_Encoding_GetByteCount.cs
@@ -16,6 +16,11 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
     public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
     {
+        if (chars.IsEmpty)
+        {
+            return 0;
+        }
+
         fixed (char* charsPtr = chars)
         {
             return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Polyfill/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Polyfill/Polyfill_Encoding_GetCharCount.cs
@@ -16,6 +16,11 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
     public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
     {
+        if (bytes.IsEmpty)
+        {
+            return 0;
+        }
+
         fixed (byte* bytesPtr = bytes)
         {
             return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Polyfill/Polyfill_Encoding_GetChars.cs
+++ b/src/Polyfill/Polyfill_Encoding_GetChars.cs
@@ -16,8 +16,19 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
     public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
     {
+        if (bytes.IsEmpty)
+        {
+            return 0;
+        }
+
+        var charsToPin = chars;
+        if (charsToPin.IsEmpty)
+        {
+            charsToPin = stackalloc char[1];
+        }
+
         fixed (byte* bytesPtr = bytes)
-        fixed (char* charsPtr = chars)
+        fixed (char* charsPtr = charsToPin)
         {
             return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
         }

--- a/src/Split/net461/Polyfill_Encoder.cs
+++ b/src/Split/net461/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net461/Polyfill_Encoding.cs
+++ b/src/Split/net461/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net461/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net461/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net461/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net461/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net461/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net461/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/net462/Polyfill_Encoder.cs
+++ b/src/Split/net462/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net462/Polyfill_Encoding.cs
+++ b/src/Split/net462/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net462/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net462/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net462/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net462/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net462/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net462/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/net47/Polyfill_Encoder.cs
+++ b/src/Split/net47/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net47/Polyfill_Encoding.cs
+++ b/src/Split/net47/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net47/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net47/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net47/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net47/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net47/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net47/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/net471/Polyfill_Encoder.cs
+++ b/src/Split/net471/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net471/Polyfill_Encoding.cs
+++ b/src/Split/net471/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net471/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net471/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net471/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net471/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net471/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net471/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/net472/Polyfill_Encoder.cs
+++ b/src/Split/net472/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net472/Polyfill_Encoding.cs
+++ b/src/Split/net472/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net472/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net472/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net472/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net472/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net472/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net472/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/net48/Polyfill_Encoder.cs
+++ b/src/Split/net48/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net48/Polyfill_Encoding.cs
+++ b/src/Split/net48/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net48/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net48/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net48/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net48/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net48/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net48/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/net481/Polyfill_Encoder.cs
+++ b/src/Split/net481/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/net481/Polyfill_Encoding.cs
+++ b/src/Split/net481/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/net481/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/net481/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/net481/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/net481/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/net481/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/net481/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/netcoreapp2.0/Polyfill_Encoder.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/netcoreapp2.0/Polyfill_Encoding.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/netcoreapp2.0/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/netcoreapp2.0/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/netcoreapp2.0/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/netstandard2.0/Polyfill_Encoder.cs
+++ b/src/Split/netstandard2.0/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/netstandard2.0/Polyfill_Encoding.cs
+++ b/src/Split/netstandard2.0/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/netstandard2.0/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/netstandard2.0/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/netstandard2.0/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/netstandard2.0/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/netstandard2.0/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/netstandard2.0/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Split/netstandard2.1/Polyfill_Encoding.cs
+++ b/src/Split/netstandard2.1/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/uap10.0/Polyfill_Encoder.cs
+++ b/src/Split/uap10.0/Polyfill_Encoder.cs
@@ -12,8 +12,18 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe void Convert(this Encoder target, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
 	{
-		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
+		fixed (char* charsPtr = charsToPin)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			target.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
 		}

--- a/src/Split/uap10.0/Polyfill_Encoding.cs
+++ b/src/Split/uap10.0/Polyfill_Encoding.cs
@@ -11,8 +11,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetBytes(this Encoding target, ReadOnlySpan<char> chars, Span<byte> bytes)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
+		var bytesToPin = bytes;
+		if (bytesToPin.IsEmpty)
+		{
+			bytesToPin = stackalloc byte[1];
+		}
 		fixed (char* charsPtr = chars)
-		fixed (byte* bytesPtr = bytes)
+		fixed (byte* bytesPtr = bytesToPin)
 		{
 			return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
 		}
@@ -29,6 +38,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return string.Empty;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetString(bytesPtr, bytes.Length);

--- a/src/Split/uap10.0/Polyfill_Encoding_GetByteCount.cs
+++ b/src/Split/uap10.0/Polyfill_Encoding_GetByteCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public unsafe static int GetByteCount(this Encoding target, ReadOnlySpan<char> chars)
 	{
+		if (chars.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (char* charsPtr = chars)
 		{
 			return target.GetByteCount(charsPtr, chars.Length);

--- a/src/Split/uap10.0/Polyfill_Encoding_GetCharCount.cs
+++ b/src/Split/uap10.0/Polyfill_Encoding_GetCharCount.cs
@@ -13,6 +13,10 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
 		fixed (byte* bytesPtr = bytes)
 		{
 			return target.GetCharCount(bytesPtr, bytes.Length);

--- a/src/Split/uap10.0/Polyfill_Encoding_GetChars.cs
+++ b/src/Split/uap10.0/Polyfill_Encoding_GetChars.cs
@@ -13,8 +13,17 @@ static partial class Polyfill
 #if AllowUnsafeBlocks
 	public static unsafe int GetChars(this Encoding target, ReadOnlySpan<byte> bytes, Span<char> chars)
 	{
+		if (bytes.IsEmpty)
+		{
+			return 0;
+		}
+		var charsToPin = chars;
+		if (charsToPin.IsEmpty)
+		{
+			charsToPin = stackalloc char[1];
+		}
 		fixed (byte* bytesPtr = bytes)
-		fixed (char* charsPtr = chars)
+		fixed (char* charsPtr = charsToPin)
 		{
 			return target.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
 		}

--- a/src/Tests/PolyfillTests_Encoder.cs
+++ b/src/Tests/PolyfillTests_Encoder.cs
@@ -48,5 +48,39 @@ partial class PolyfillTests
         await Assert.That(completed).IsTrue();
         await Assert.That(bytes).IsEquivalentTo(Encoding.UTF8.GetBytes(text));
     }
+
+    [Test]
+    public async Task Encoder_Convert_EmptySource()
+    {
+        var encoder = Encoding.UTF8.GetEncoder();
+        ReadOnlySpan<char> chars = default;
+        var bytes = new byte[1];
+
+        encoder.Convert(chars, bytes, true, out var charsUsed, out var bytesUsed, out var completed);
+
+        await Assert.That(charsUsed).IsEqualTo(0);
+        await Assert.That(bytesUsed).IsEqualTo(0);
+        await Assert.That(completed).IsTrue();
+    }
+
+    [Test]
+    public async Task Encoder_Convert_EmptyDestination()
+    {
+        var encoder = Encoding.UTF8.GetEncoder();
+        ReadOnlySpan<char> chars = "value";
+        Span<byte> bytes = default;
+        Exception? exception = null;
+
+        try
+        {
+            encoder.Convert(chars, bytes, false, out _, out _, out _);
+        }
+        catch (Exception caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception?.GetType()).IsEqualTo(typeof(ArgumentException));
+    }
 }
 #endif

--- a/src/Tests/PolyfillTests_Encoding.cs
+++ b/src/Tests/PolyfillTests_Encoding.cs
@@ -27,6 +27,16 @@ partial class PolyfillTests
     }
 
     [Test]
+    public async Task Encoding_GetByteCount_EmptySource()
+    {
+        ReadOnlySpan<char> chars = default;
+
+        var byteCount = Encoding.UTF8.GetByteCount(chars);
+
+        await Assert.That(byteCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Encoding_GetChars()
     {
         // Arrange
@@ -62,11 +72,51 @@ partial class PolyfillTests
     }
 
     [Test]
+    public async Task Encoding_GetChars_EmptySource()
+    {
+        ReadOnlySpan<byte> bytes = default;
+        var chars = new char[1];
+
+        var charCount = Encoding.UTF8.GetChars(bytes, chars);
+
+        await Assert.That(charCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Encoding_GetChars_EmptyDestination()
+    {
+        ReadOnlySpan<byte> bytes = "value"u8;
+        Span<char> chars = default;
+        Exception? exception = null;
+
+        try
+        {
+            Encoding.UTF8.GetChars(bytes, chars);
+        }
+        catch (Exception caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception?.GetType()).IsEqualTo(typeof(ArgumentException));
+    }
+
+    [Test]
     public async Task Encoding_GetString()
     {
         var array = (ReadOnlySpan<byte>)"value"u8.ToArray().AsSpan();
         var result = Encoding.UTF8.GetString(array);
         await Assert.That(result).IsEqualTo("value");
+    }
+
+    [Test]
+    public async Task Encoding_GetString_EmptySource()
+    {
+        ReadOnlySpan<byte> bytes = default;
+
+        var result = Encoding.UTF8.GetString(bytes);
+
+        await Assert.That(result).IsEmpty();
     }
 
     [Test]
@@ -89,6 +139,36 @@ partial class PolyfillTests
         }
 
         return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Encoding_GetBytes_EmptySource()
+    {
+        ReadOnlySpan<char> chars = default;
+        var bytes = new byte[1];
+
+        var byteCount = Encoding.UTF8.GetBytes(chars, bytes);
+
+        await Assert.That(byteCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Encoding_GetBytes_EmptyDestination()
+    {
+        ReadOnlySpan<char> chars = "value";
+        Span<byte> bytes = default;
+        Exception? exception = null;
+
+        try
+        {
+            Encoding.UTF8.GetBytes(chars, bytes);
+        }
+        catch (Exception caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception?.GetType()).IsEqualTo(typeof(ArgumentException));
     }
 
     [Test]
@@ -126,6 +206,16 @@ partial class PolyfillTests
         var byteSpan = new ReadOnlySpan<byte>(utf8Bytes);
         var charCount = encoding.GetCharCount(byteSpan);
         await Assert.That(charCount).IsEqualTo(13);
+    }
+
+    [Test]
+    public async Task Encoding_GetCharCount_EmptySource()
+    {
+        ReadOnlySpan<byte> bytes = default;
+
+        var charCount = Encoding.UTF8.GetCharCount(bytes);
+
+        await Assert.That(charCount).IsEqualTo(0);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- short-circuit stateless `Encoding` span overloads for empty input
- use non-null stack storage for empty destinations and stateful `Encoder.Convert`
- add empty-source and empty-destination regression coverage
- regenerate Split sources, assembly-size data, and README snippets

## Root cause

Pinning an empty span produces a null pointer. The pointer-based encoding overloads reject null pointers even when the corresponding length is zero, unlike the native span overloads.

## Validation

- `dotnet run --project src/ApiBuilderTests/ApiBuilderTests.csproj --configuration Debug` — 71 passed
- `dotnet build src/Polyfill.slnx --configuration Release` — succeeded, 0 errors
- `pwsh ./src/run-tests.ps1` — full project/framework matrix passed

Closes #569