### PR TITLE
Add net11 RC1 Process exit status APIs

### DIFF
--- a/apiCount.include.md
+++ b/apiCount.include.md
@@ -1,28 +1,28 @@
-**API count: 1034**
+**API count: 1038**
 
 ### Per Target Framework
 
 | Target | APIs |
 | -- | -- |
-| `net461` | 976 |
-| `net462` | 976 |
-| `net47` | 975 |
-| `net471` | 974 |
-| `net472` | 970 |
-| `net48` | 970 |
-| `net481` | 970 |
-| `netstandard2.0` | 972 |
-| `netstandard2.1` | 825 |
-| `netcoreapp2.0` | 895 |
-| `netcoreapp2.1` | 836 |
-| `netcoreapp2.2` | 836 |
-| `netcoreapp3.0` | 788 |
-| `netcoreapp3.1` | 787 |
-| `net5.0` | 659 |
-| `net6.0` | 560 |
-| `net7.0` | 405 |
-| `net8.0` | 286 |
-| `net9.0` | 192 |
-| `net10.0` | 138 |
+| `net461` | 980 |
+| `net462` | 980 |
+| `net47` | 979 |
+| `net471` | 978 |
+| `net472` | 974 |
+| `net48` | 974 |
+| `net481` | 974 |
+| `netstandard2.0` | 976 |
+| `netstandard2.1` | 829 |
+| `netcoreapp2.0` | 899 |
+| `netcoreapp2.1` | 840 |
+| `netcoreapp2.2` | 840 |
+| `netcoreapp3.0` | 792 |
+| `netcoreapp3.1` | 791 |
+| `net5.0` | 663 |
+| `net6.0` | 564 |
+| `net7.0` | 409 |
+| `net8.0` | 290 |
+| `net9.0` | 196 |
+| `net10.0` | 142 |
 | `net11.0` | 58 |
-| `uap10.0` | 962 |
+| `uap10.0` | 966 |

--- a/api_list.include.md
+++ b/api_list.include.md
@@ -793,7 +793,16 @@
  * `IAsyncEnumerable<ProcessOutputLine> ReadAllLinesAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllinesasync?view=net-11.0)
  * `(string StandardOutput, string StandardError) ReadAllText(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltext?view=net-11.0)
  * `Task<(string StandardOutput, string StandardError)> ReadAllTextAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltextasync?view=net-11.0)
+ * `bool Signal(PosixSignal)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.signal?view=net-11.0)
+   * Note: On Windows, as on net11, only SIGKILL is supported and is mapped to Process.Kill. All other signals throw PlatformNotSupportedException.
+   * Note: PosixSignal.SIGKILL was added in net11, so it cannot be named on earlier target frameworks. Its numeric value, (PosixSignal)(-11), is accepted.
+ * `bool TryWaitForExitStatus(TimeSpan, ProcessExitStatus?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.trywaitforexitstatus?view=net-11.0)
+   * Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
  * `Task WaitForExitAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitasync?view=net-11.0)
+ * `ProcessExitStatus WaitForExitStatus()` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitstatus?view=net-11.0)
+   * Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
+ * `Task<ProcessExitStatus> WaitForExitStatusAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitstatusasync?view=net-11.0)
+   * Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
  * `ProcessExitStatus Run(ProcessStartInfo, TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.run?view=net-11.0#system-diagnostics-process-run(system-diagnostics-processstartinfo-system-nullable((system-timespan))))
  * `ProcessExitStatus Run(string, IList<string>?, bool, TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.run?view=net-11.0#system-diagnostics-process-run(system-string-system-collections-generic-ilist((system-string))-system-boolean-system-nullable((system-timespan))))
    * Note: When silent is true, standard output and error are suppressed by redirecting and discarding them (rather than binding to the null device as on net11); standard input remains connected.

--- a/assemblySize.include.md
+++ b/assemblySize.include.md
@@ -2,51 +2,51 @@
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       359.0KB |  +351.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
-| netstandard2.1 |          8.5KB |       313.0KB |  +304.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net461         |          8.5KB |       357.5KB |  +349.0KB |    +8.0KB |             +7.0KB |              +8.0KB |     +12.5KB |
-| net462         |          7.0KB |       361.0KB |  +354.0KB |    +9.5KB |             +6.5KB |              +9.5KB |     +14.0KB |
-| net47          |          7.0KB |       361.0KB |  +354.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net471         |          8.5KB |       360.0KB |  +351.5KB |    +7.5KB |             +6.5KB |              +8.0KB |     +12.5KB |
-| net472         |          8.5KB |       358.5KB |  +350.0KB |    +8.0KB |             +7.0KB |              +8.0KB |     +12.5KB |
-| net48          |          8.5KB |       358.5KB |  +350.0KB |    +8.0KB |             +7.0KB |              +8.0KB |     +12.5KB |
-| net481         |          8.5KB |       359.0KB |  +350.5KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
-| netcoreapp2.0  |          9.0KB |       336.5KB |  +327.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp2.1  |          9.0KB |       316.5KB |  +307.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp2.2  |          9.0KB |       316.5KB |  +307.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp3.0  |          9.5KB |       309.5KB |  +300.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.1  |          9.5KB |       308.0KB |  +298.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net5.0         |          9.5KB |       272.0KB |  +262.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net6.0         |         10.0KB |       213.0KB |  +203.0KB |   +10.0KB |             +7.0KB |              +1.0KB |      +3.5KB |
-| net7.0         |         10.0KB |       175.0KB |  +165.0KB |   +12.0KB |             +8.5KB |           +512bytes |      +3.5KB |
-| net8.0         |          9.5KB |       145.5KB |  +136.0KB |    +8.5KB |          +512bytes |           +512bytes |      +3.5KB |
-| net9.0         |          9.5KB |        98.5KB |   +89.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net10.0        |         10.0KB |        76.0KB |   +66.0KB |    +9.0KB |                    |              +1.0KB |      +3.5KB |
-| net11.0        |         10.0KB |        21.0KB |   +11.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
+| netstandard2.0 |          8.0KB |       361.5KB |  +353.5KB |    +7.5KB |             +7.0KB |              +8.0KB |     +12.5KB |
+| netstandard2.1 |          8.5KB |       315.5KB |  +307.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net461         |          8.5KB |       360.5KB |  +352.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| net462         |          7.0KB |       364.0KB |  +357.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net47          |          7.0KB |       363.5KB |  +356.5KB |    +9.5KB |             +6.5KB |              +9.5KB |     +14.0KB |
+| net471         |          8.5KB |       363.0KB |  +354.5KB |    +7.5KB |             +5.0KB |              +7.5KB |     +12.0KB |
+| net472         |          8.5KB |       361.5KB |  +353.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| net48          |          8.5KB |       361.5KB |  +353.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| net481         |          8.5KB |       361.5KB |  +353.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| netcoreapp2.0  |          9.0KB |       339.0KB |  +330.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netcoreapp2.1  |          9.0KB |       319.0KB |  +310.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| netcoreapp2.2  |          9.0KB |       319.0KB |  +310.0KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
+| netcoreapp3.0  |          9.5KB |       312.5KB |  +303.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netcoreapp3.1  |          9.5KB |       310.5KB |  +301.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net5.0         |          9.5KB |       274.5KB |  +265.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net6.0         |         10.0KB |       216.0KB |  +206.0KB |   +10.0KB |             +7.0KB |           +512bytes |      +3.5KB |
+| net7.0         |         10.0KB |       178.0KB |  +168.0KB |   +12.0KB |             +8.0KB |           +512bytes |      +3.5KB |
+| net8.0         |          9.5KB |       148.5KB |  +139.0KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
+| net9.0         |          9.5KB |       101.5KB |   +92.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net10.0        |         10.0KB |        79.0KB |   +69.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net11.0        |         10.0KB |        20.5KB |   +10.5KB |    +9.5KB |          +512bytes |              +1.0KB |      +4.0KB |
 
 
 ### Assembly Sizes with EmbedUntrackedSources
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       526.3KB |  +518.3KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
-| netstandard2.1 |          8.5KB |       453.6KB |  +445.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net461         |          8.5KB |       525.8KB |  +517.3KB |   +15.7KB |             +8.7KB |             +12.9KB |     +17.9KB |
-| net462         |          7.0KB |       529.3KB |  +522.3KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| net47          |          7.0KB |       529.1KB |  +522.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net471         |          8.5KB |       527.7KB |  +519.2KB |   +15.2KB |             +8.2KB |             +12.9KB |     +17.9KB |
-| net472         |          8.5KB |       525.1KB |  +516.6KB |   +15.7KB |             +8.7KB |             +12.9KB |     +17.9KB |
-| net48          |          8.5KB |       525.1KB |  +516.6KB |   +15.7KB |             +8.7KB |             +12.9KB |     +17.9KB |
-| net481         |          8.5KB |       525.6KB |  +517.1KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
-| netcoreapp2.0  |          9.0KB |       493.2KB |  +484.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp2.1  |          9.0KB |       460.9KB |  +451.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp2.2  |          9.0KB |       460.9KB |  +451.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp3.0  |          9.5KB |       445.0KB |  +435.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.1  |          9.5KB |       443.4KB |  +433.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net5.0         |          9.5KB |       389.3KB |  +379.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net6.0         |         10.0KB |       310.1KB |  +300.1KB |   +17.7KB |             +8.7KB |              +1.6KB |      +4.2KB |
-| net7.0         |         10.0KB |       253.2KB |  +243.2KB |   +19.6KB |             +9.9KB |              +1.1KB |      +4.2KB |
-| net8.0         |          9.5KB |       208.2KB |  +198.7KB |   +16.0KB |          +811bytes |              +1.1KB |      +4.2KB |
-| net9.0         |          9.5KB |       140.1KB |  +130.6KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
-| net10.0        |         10.0KB |       108.9KB |   +98.9KB |   +16.5KB |                    |              +1.6KB |      +4.2KB |
-| net11.0        |         10.0KB |        30.9KB |   +20.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
+| netstandard2.0 |          8.0KB |       530.1KB |  +522.1KB |   +15.2KB |             +8.7KB |             +12.9KB |     +17.9KB |
+| netstandard2.1 |          8.5KB |       457.5KB |  +449.0KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net461         |          8.5KB |       530.1KB |  +521.6KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| net462         |          7.0KB |       533.6KB |  +526.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net47          |          7.0KB |       532.9KB |  +525.9KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| net471         |          8.5KB |       532.0KB |  +523.5KB |   +15.2KB |             +6.7KB |             +12.4KB |     +17.4KB |
+| net472         |          8.5KB |       529.5KB |  +521.0KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| net48          |          8.5KB |       529.5KB |  +521.0KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| net481         |          8.5KB |       529.5KB |  +521.0KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| netcoreapp2.0  |          9.0KB |       497.0KB |  +488.0KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netcoreapp2.1  |          9.0KB |       464.7KB |  +455.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| netcoreapp2.2  |          9.0KB |       464.7KB |  +455.7KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netcoreapp3.0  |          9.5KB |       449.3KB |  +439.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netcoreapp3.1  |          9.5KB |       447.3KB |  +437.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net5.0         |          9.5KB |       393.2KB |  +383.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net6.0         |         10.0KB |       314.5KB |  +304.5KB |   +17.7KB |             +8.7KB |              +1.1KB |      +4.2KB |
+| net7.0         |         10.0KB |       257.6KB |  +247.6KB |   +19.6KB |             +9.4KB |              +1.1KB |      +4.2KB |
+| net8.0         |          9.5KB |       212.7KB |  +203.2KB |   +16.0KB |          +299bytes |              +1.1KB |      +3.7KB |
+| net9.0         |          9.5KB |       144.5KB |  +135.0KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
+| net10.0        |         10.0KB |       113.4KB |  +103.4KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
+| net11.0        |         10.0KB |        30.4KB |   +20.4KB |   +17.0KB |          +512bytes |              +1.6KB |      +4.7KB |

--- a/readme.md
+++ b/readme.md
@@ -13,34 +13,34 @@ The package targets `netstandard2.0` and is designed to support the following ru
  * `uap10`
 
 
-**API count: 1034**<!-- include: apiCount. path: /apiCount.include.md -->
+**API count: 1038**<!-- include: apiCount. path: /apiCount.include.md -->
 
 ### Per Target Framework
 
 | Target | APIs |
 | -- | -- |
-| `net461` | 976 |
-| `net462` | 976 |
-| `net47` | 975 |
-| `net471` | 974 |
-| `net472` | 970 |
-| `net48` | 970 |
-| `net481` | 970 |
-| `netstandard2.0` | 972 |
-| `netstandard2.1` | 825 |
-| `netcoreapp2.0` | 895 |
-| `netcoreapp2.1` | 836 |
-| `netcoreapp2.2` | 836 |
-| `netcoreapp3.0` | 788 |
-| `netcoreapp3.1` | 787 |
-| `net5.0` | 659 |
-| `net6.0` | 560 |
-| `net7.0` | 405 |
-| `net8.0` | 286 |
-| `net9.0` | 192 |
-| `net10.0` | 138 |
+| `net461` | 980 |
+| `net462` | 980 |
+| `net47` | 979 |
+| `net471` | 978 |
+| `net472` | 974 |
+| `net48` | 974 |
+| `net481` | 974 |
+| `netstandard2.0` | 976 |
+| `netstandard2.1` | 829 |
+| `netcoreapp2.0` | 899 |
+| `netcoreapp2.1` | 840 |
+| `netcoreapp2.2` | 840 |
+| `netcoreapp3.0` | 792 |
+| `netcoreapp3.1` | 791 |
+| `net5.0` | 663 |
+| `net6.0` | 564 |
+| `net7.0` | 409 |
+| `net8.0` | 290 |
+| `net9.0` | 196 |
+| `net10.0` | 142 |
 | `net11.0` | 58 |
-| `uap10.0` | 962 |
+| `uap10.0` | 966 |
 <!-- endInclude -->
 
 
@@ -96,54 +96,54 @@ This project uses features from the newest stable SDK and C# language. As such c
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       359.0KB |  +351.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
-| netstandard2.1 |          8.5KB |       313.0KB |  +304.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net461         |          8.5KB |       357.5KB |  +349.0KB |    +8.0KB |             +7.0KB |              +8.0KB |     +12.5KB |
-| net462         |          7.0KB |       361.0KB |  +354.0KB |    +9.5KB |             +6.5KB |              +9.5KB |     +14.0KB |
-| net47          |          7.0KB |       361.0KB |  +354.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net471         |          8.5KB |       360.0KB |  +351.5KB |    +7.5KB |             +6.5KB |              +8.0KB |     +12.5KB |
-| net472         |          8.5KB |       358.5KB |  +350.0KB |    +8.0KB |             +7.0KB |              +8.0KB |     +12.5KB |
-| net48          |          8.5KB |       358.5KB |  +350.0KB |    +8.0KB |             +7.0KB |              +8.0KB |     +12.5KB |
-| net481         |          8.5KB |       359.0KB |  +350.5KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
-| netcoreapp2.0  |          9.0KB |       336.5KB |  +327.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp2.1  |          9.0KB |       316.5KB |  +307.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp2.2  |          9.0KB |       316.5KB |  +307.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| netcoreapp3.0  |          9.5KB |       309.5KB |  +300.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.1  |          9.5KB |       308.0KB |  +298.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net5.0         |          9.5KB |       272.0KB |  +262.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net6.0         |         10.0KB |       213.0KB |  +203.0KB |   +10.0KB |             +7.0KB |              +1.0KB |      +3.5KB |
-| net7.0         |         10.0KB |       175.0KB |  +165.0KB |   +12.0KB |             +8.5KB |           +512bytes |      +3.5KB |
-| net8.0         |          9.5KB |       145.5KB |  +136.0KB |    +8.5KB |          +512bytes |           +512bytes |      +3.5KB |
-| net9.0         |          9.5KB |        98.5KB |   +89.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net10.0        |         10.0KB |        76.0KB |   +66.0KB |    +9.0KB |                    |              +1.0KB |      +3.5KB |
-| net11.0        |         10.0KB |        21.0KB |   +11.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
+| netstandard2.0 |          8.0KB |       361.5KB |  +353.5KB |    +7.5KB |             +7.0KB |              +8.0KB |     +12.5KB |
+| netstandard2.1 |          8.5KB |       315.5KB |  +307.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net461         |          8.5KB |       360.5KB |  +352.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| net462         |          7.0KB |       364.0KB |  +357.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net47          |          7.0KB |       363.5KB |  +356.5KB |    +9.5KB |             +6.5KB |              +9.5KB |     +14.0KB |
+| net471         |          8.5KB |       363.0KB |  +354.5KB |    +7.5KB |             +5.0KB |              +7.5KB |     +12.0KB |
+| net472         |          8.5KB |       361.5KB |  +353.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| net48          |          8.5KB |       361.5KB |  +353.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| net481         |          8.5KB |       361.5KB |  +353.0KB |    +7.5KB |             +6.5KB |              +7.5KB |     +12.0KB |
+| netcoreapp2.0  |          9.0KB |       339.0KB |  +330.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netcoreapp2.1  |          9.0KB |       319.0KB |  +310.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| netcoreapp2.2  |          9.0KB |       319.0KB |  +310.0KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
+| netcoreapp3.0  |          9.5KB |       312.5KB |  +303.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netcoreapp3.1  |          9.5KB |       310.5KB |  +301.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net5.0         |          9.5KB |       274.5KB |  +265.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net6.0         |         10.0KB |       216.0KB |  +206.0KB |   +10.0KB |             +7.0KB |           +512bytes |      +3.5KB |
+| net7.0         |         10.0KB |       178.0KB |  +168.0KB |   +12.0KB |             +8.0KB |           +512bytes |      +3.5KB |
+| net8.0         |          9.5KB |       148.5KB |  +139.0KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
+| net9.0         |          9.5KB |       101.5KB |   +92.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net10.0        |         10.0KB |        79.0KB |   +69.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net11.0        |         10.0KB |        20.5KB |   +10.5KB |    +9.5KB |          +512bytes |              +1.0KB |      +4.0KB |
 
 
 ### Assembly Sizes with EmbedUntrackedSources
 
 |                | Empty Assembly | With Polyfill | Diff      | Ensure    | ArgumentExceptions | StringInterpolation | Nullability |
 |----------------|----------------|---------------|-----------|-----------|--------------------|---------------------|-------------|
-| netstandard2.0 |          8.0KB |       526.3KB |  +518.3KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
-| netstandard2.1 |          8.5KB |       453.6KB |  +445.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net461         |          8.5KB |       525.8KB |  +517.3KB |   +15.7KB |             +8.7KB |             +12.9KB |     +17.9KB |
-| net462         |          7.0KB |       529.3KB |  +522.3KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| net47          |          7.0KB |       529.1KB |  +522.1KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net471         |          8.5KB |       527.7KB |  +519.2KB |   +15.2KB |             +8.2KB |             +12.9KB |     +17.9KB |
-| net472         |          8.5KB |       525.1KB |  +516.6KB |   +15.7KB |             +8.7KB |             +12.9KB |     +17.9KB |
-| net48          |          8.5KB |       525.1KB |  +516.6KB |   +15.7KB |             +8.7KB |             +12.9KB |     +17.9KB |
-| net481         |          8.5KB |       525.6KB |  +517.1KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
-| netcoreapp2.0  |          9.0KB |       493.2KB |  +484.2KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp2.1  |          9.0KB |       460.9KB |  +451.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp2.2  |          9.0KB |       460.9KB |  +451.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| netcoreapp3.0  |          9.5KB |       445.0KB |  +435.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.1  |          9.5KB |       443.4KB |  +433.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net5.0         |          9.5KB |       389.3KB |  +379.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net6.0         |         10.0KB |       310.1KB |  +300.1KB |   +17.7KB |             +8.7KB |              +1.6KB |      +4.2KB |
-| net7.0         |         10.0KB |       253.2KB |  +243.2KB |   +19.6KB |             +9.9KB |              +1.1KB |      +4.2KB |
-| net8.0         |          9.5KB |       208.2KB |  +198.7KB |   +16.0KB |          +811bytes |              +1.1KB |      +4.2KB |
-| net9.0         |          9.5KB |       140.1KB |  +130.6KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
-| net10.0        |         10.0KB |       108.9KB |   +98.9KB |   +16.5KB |                    |              +1.6KB |      +4.2KB |
-| net11.0        |         10.0KB |        30.9KB |   +20.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
+| netstandard2.0 |          8.0KB |       530.1KB |  +522.1KB |   +15.2KB |             +8.7KB |             +12.9KB |     +17.9KB |
+| netstandard2.1 |          8.5KB |       457.5KB |  +449.0KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net461         |          8.5KB |       530.1KB |  +521.6KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| net462         |          7.0KB |       533.6KB |  +526.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net47          |          7.0KB |       532.9KB |  +525.9KB |   +17.2KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| net471         |          8.5KB |       532.0KB |  +523.5KB |   +15.2KB |             +6.7KB |             +12.4KB |     +17.4KB |
+| net472         |          8.5KB |       529.5KB |  +521.0KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| net48          |          8.5KB |       529.5KB |  +521.0KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| net481         |          8.5KB |       529.5KB |  +521.0KB |   +15.2KB |             +8.2KB |             +12.4KB |     +17.4KB |
+| netcoreapp2.0  |          9.0KB |       497.0KB |  +488.0KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netcoreapp2.1  |          9.0KB |       464.7KB |  +455.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| netcoreapp2.2  |          9.0KB |       464.7KB |  +455.7KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
+| netcoreapp3.0  |          9.5KB |       449.3KB |  +439.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netcoreapp3.1  |          9.5KB |       447.3KB |  +437.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net5.0         |          9.5KB |       393.2KB |  +383.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net6.0         |         10.0KB |       314.5KB |  +304.5KB |   +17.7KB |             +8.7KB |              +1.1KB |      +4.2KB |
+| net7.0         |         10.0KB |       257.6KB |  +247.6KB |   +19.6KB |             +9.4KB |              +1.1KB |      +4.2KB |
+| net8.0         |          9.5KB |       212.7KB |  +203.2KB |   +16.0KB |          +299bytes |              +1.1KB |      +3.7KB |
+| net9.0         |          9.5KB |       144.5KB |  +135.0KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
+| net10.0        |         10.0KB |       113.4KB |  +103.4KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
+| net11.0        |         10.0KB |        30.4KB |   +20.4KB |   +17.0KB |          +512bytes |              +1.6KB |      +4.7KB |
 <!-- endInclude -->
 
 
@@ -1408,7 +1408,16 @@ The class `Polyfill` includes the following extension methods:
  * `IAsyncEnumerable<ProcessOutputLine> ReadAllLinesAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllinesasync?view=net-11.0)
  * `(string StandardOutput, string StandardError) ReadAllText(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltext?view=net-11.0)
  * `Task<(string StandardOutput, string StandardError)> ReadAllTextAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltextasync?view=net-11.0)
+ * `bool Signal(PosixSignal)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.signal?view=net-11.0)
+   * Note: On Windows, as on net11, only SIGKILL is supported and is mapped to Process.Kill. All other signals throw PlatformNotSupportedException.
+   * Note: PosixSignal.SIGKILL was added in net11, so it cannot be named on earlier target frameworks. Its numeric value, (PosixSignal)(-11), is accepted.
+ * `bool TryWaitForExitStatus(TimeSpan, ProcessExitStatus?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.trywaitforexitstatus?view=net-11.0)
+   * Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
  * `Task WaitForExitAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitasync?view=net-11.0)
+ * `ProcessExitStatus WaitForExitStatus()` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitstatus?view=net-11.0)
+   * Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
+ * `Task<ProcessExitStatus> WaitForExitStatusAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitstatusasync?view=net-11.0)
+   * Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
  * `ProcessExitStatus Run(ProcessStartInfo, TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.run?view=net-11.0#system-diagnostics-process-run(system-diagnostics-processstartinfo-system-nullable((system-timespan))))
  * `ProcessExitStatus Run(string, IList<string>?, bool, TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.run?view=net-11.0#system-diagnostics-process-run(system-string-system-collections-generic-ilist((system-string))-system-boolean-system-nullable((system-timespan))))
    * Note: When silent is true, standard output and error are suppressed by redirecting and discarding them (rather than binding to the null device as on net11); standard input remains connected.

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -1356,6 +1356,13 @@ class Consume
         await process.WaitForExitAsync();
         process.Kill(true);
 
+        bool signaled = process.Signal(PosixSignal.SIGTERM);
+        ProcessExitStatus waitStatus = process.WaitForExitStatus();
+        bool waitExited = process.TryWaitForExitStatus(TimeSpan.FromSeconds(1), out ProcessExitStatus? waitExitStatus);
+        _ = waitExitStatus;
+        waitStatus = await process.WaitForExitStatusAsync();
+        waitStatus = await process.WaitForExitStatusAsync(CancellationToken.None);
+
 #if FeatureValueTuple
         (string outText, string errText) = process.ReadAllText();
         (outText, errText) = process.ReadAllText(TimeSpan.FromSeconds(1));

--- a/src/Polyfill/Polyfill_Process.cs
+++ b/src/Polyfill/Polyfill_Process.cs
@@ -2,9 +2,12 @@ namespace Polyfills;
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -209,6 +212,220 @@ static partial class Polyfill
         }
     }
 #endif
+
+    /// <summary>
+    /// Sends the specified POSIX signal to the associated process.
+    /// </summary>
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.signal?view=net-11.0
+    //Note: On Windows, as on net11, only SIGKILL is supported and is mapped to Process.Kill. All other signals throw PlatformNotSupportedException.
+    //Note: PosixSignal.SIGKILL was added in net11, so it cannot be named on earlier target frameworks. Its numeric value, (PosixSignal)(-11), is accepted.
+    [SupportedOSPlatform("maccatalyst")]
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    public static bool Signal(this Process target, PosixSignal signal)
+    {
+        if (SignalHelper.IsWindows)
+        {
+            if (target.HasExited)
+            {
+                // matches net11, where opening a handle to an exited process fails
+                return false;
+            }
+
+            if ((int) signal != SignalHelper.SigKill)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            try
+            {
+                target.Kill();
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                // the process exited between the check and the kill
+                return false;
+            }
+        }
+
+        return SignalHelper.Send(target.Id, signal);
+    }
+
+    /// <summary>
+    /// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+    /// </summary>
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitstatus?view=net-11.0
+    //Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
+    [SupportedOSPlatform("maccatalyst")]
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    public static ProcessExitStatus WaitForExitStatus(this Process target)
+    {
+        target.WaitForExit();
+        return ToExitStatus(target.ExitCode);
+    }
+
+    /// <summary>
+    /// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+    /// and returns a value indicating whether it exited.
+    /// </summary>
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.trywaitforexitstatus?view=net-11.0
+    //Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
+    [SupportedOSPlatform("maccatalyst")]
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+    {
+        var milliseconds = ToTimeoutMilliseconds(timeout);
+        if (!target.WaitForExit(milliseconds))
+        {
+            exitStatus = null;
+            return false;
+        }
+
+        exitStatus = ToExitStatus(target.ExitCode);
+        return true;
+    }
+
+    /// <summary>
+    /// Instructs the Process component to wait for the associated process to exit, or for the
+    /// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+    /// </summary>
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexitstatusasync?view=net-11.0
+    //Note: On Unix the terminating signal is derived from the exit code, which is 128 plus the signal number, instead of from the raw wait status. A process that exits normally with, for example, code 143 is therefore reported as terminated by SIGTERM.
+    [SupportedOSPlatform("maccatalyst")]
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+    {
+        await target.WaitForExitAsync(cancellationToken);
+        return ToExitStatus(target.ExitCode);
+    }
+
+    static ProcessExitStatus ToExitStatus(int exitCode)
+    {
+        if (!SignalHelper.IsWindows)
+        {
+            // Unix reports termination by a signal as an exit code of 128 plus the signal number
+            var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+            if (signal != null)
+            {
+                return new(exitCode, canceled: false, signal);
+            }
+        }
+
+        return new(exitCode, canceled: false);
+    }
+
+    static int ToTimeoutMilliseconds(TimeSpan timeout)
+    {
+        var milliseconds = (long) timeout.TotalMilliseconds;
+        if (milliseconds < -1 ||
+            milliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+        }
+
+        return (int) milliseconds;
+    }
+
+    [ExcludeFromCodeCoverage]
+    [DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+    [global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+    static class SignalHelper
+    {
+        /// <summary>
+        /// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+        /// </summary>
+        public const int SigKill = -11;
+
+        const int ESRCH = 3;
+
+#if FeatureRuntimeInformation
+        public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // macOS and the BSDs number SIGCHLD, SIGCONT and SIGTSTP differently to Linux
+        static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+                                     RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+        public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+
+        public static bool Send(int processId, PosixSignal signal)
+        {
+            var number = ToSignalNumber(signal);
+            if (number == 0)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            if (kill(processId, number) == 0)
+            {
+                return true;
+            }
+
+            var error = Marshal.GetLastWin32Error();
+            if (error == ESRCH)
+            {
+                // the process has already exited, or never existed
+                return false;
+            }
+
+            throw new Win32Exception(error);
+        }
+
+        static int ToSignalNumber(PosixSignal signal)
+        {
+            var value = (int) signal;
+            // positive values are platform signal numbers
+            if (value > 0)
+            {
+                return value;
+            }
+
+            return value switch
+            {
+                -1 => 1, // SIGHUP
+                -2 => 2, // SIGINT
+                -3 => 3, // SIGQUIT
+                -4 => 15, // SIGTERM
+                -5 => isBsd ? 20 : 17, // SIGCHLD
+                -6 => isBsd ? 19 : 18, // SIGCONT
+                -7 => 28, // SIGWINCH
+                -8 => 21, // SIGTTIN
+                -9 => 22, // SIGTTOU
+                -10 => isBsd ? 18 : 20, // SIGTSTP
+                SigKill => 9, // SIGKILL
+                _ => 0
+            };
+        }
+
+        public static PosixSignal? ToPosixSignal(int number) =>
+            number switch
+            {
+                1 => PosixSignal.SIGHUP,
+                2 => PosixSignal.SIGINT,
+                3 => PosixSignal.SIGQUIT,
+                9 => (PosixSignal) SigKill,
+                15 => PosixSignal.SIGTERM,
+                17 => isBsd ? null : PosixSignal.SIGCHLD,
+                18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+                19 => isBsd ? PosixSignal.SIGCONT : null,
+                20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+                21 => PosixSignal.SIGTTIN,
+                22 => PosixSignal.SIGTTOU,
+                28 => PosixSignal.SIGWINCH,
+                _ => null
+            };
+
+        [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+        static extern int kill(int pid, int signal);
+    }
 
     static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
     {

--- a/src/Polyfill/ProcessPolyfill.cs
+++ b/src/Polyfill/ProcessPolyfill.cs
@@ -25,7 +25,7 @@ static partial class Polyfill
         {
             using var process = StartOrThrow(startInfo);
             WaitForExitOrThrow(process, timeout);
-            return new(process.ExitCode, canceled: false);
+            return ToExitStatus(process.ExitCode);
         }
 
         /// <summary>
@@ -73,7 +73,13 @@ static partial class Polyfill
                 {
                 }
             }
-            return new(canceled ? -1 : process.ExitCode, canceled);
+
+            if (canceled)
+            {
+                return new(-1, canceled: true);
+            }
+
+            return ToExitStatus(process.ExitCode);
         }
 
         /// <summary>
@@ -109,7 +115,7 @@ static partial class Polyfill
             var stderrTask = process.StandardError.ReadToEndAsync();
             var pid = process.Id;
             WaitForExitOrThrow(process, timeout);
-            var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+            var status = ToExitStatus(process.ExitCode);
             return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
         }
 
@@ -154,7 +160,7 @@ static partial class Polyfill
                 {
                 }
             }
-            var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+            var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
             return new(status, await stdoutTask, await stderrTask, pid);
         }
 

--- a/src/Split/net10.0/Polyfill_Process.cs
+++ b/src/Split/net10.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -133,6 +136,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net10.0/ProcessPolyfill.cs
+++ b/src/Split/net10.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net461/Polyfill_Process.cs
+++ b/src/Split/net461/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net461/ProcessPolyfill.cs
+++ b/src/Split/net461/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net462/Polyfill_Process.cs
+++ b/src/Split/net462/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net462/ProcessPolyfill.cs
+++ b/src/Split/net462/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net47/Polyfill_Process.cs
+++ b/src/Split/net47/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net47/ProcessPolyfill.cs
+++ b/src/Split/net47/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net471/Polyfill_Process.cs
+++ b/src/Split/net471/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net471/ProcessPolyfill.cs
+++ b/src/Split/net471/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net472/Polyfill_Process.cs
+++ b/src/Split/net472/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net472/ProcessPolyfill.cs
+++ b/src/Split/net472/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net48/Polyfill_Process.cs
+++ b/src/Split/net48/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net48/ProcessPolyfill.cs
+++ b/src/Split/net48/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net481/Polyfill_Process.cs
+++ b/src/Split/net481/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net481/ProcessPolyfill.cs
+++ b/src/Split/net481/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net5.0/Polyfill_Process.cs
+++ b/src/Split/net5.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -133,6 +136,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net5.0/ProcessPolyfill.cs
+++ b/src/Split/net5.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net6.0/Polyfill_Process.cs
+++ b/src/Split/net6.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -133,6 +136,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net6.0/ProcessPolyfill.cs
+++ b/src/Split/net6.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net7.0/Polyfill_Process.cs
+++ b/src/Split/net7.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -133,6 +136,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net7.0/ProcessPolyfill.cs
+++ b/src/Split/net7.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net8.0/Polyfill_Process.cs
+++ b/src/Split/net8.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -133,6 +136,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net8.0/ProcessPolyfill.cs
+++ b/src/Split/net8.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/net9.0/Polyfill_Process.cs
+++ b/src/Split/net9.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -133,6 +136,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/net9.0/ProcessPolyfill.cs
+++ b/src/Split/net9.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netcoreapp2.0/Polyfill_Process.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netcoreapp2.0/ProcessPolyfill.cs
+++ b/src/Split/netcoreapp2.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netcoreapp2.1/Polyfill_Process.cs
+++ b/src/Split/netcoreapp2.1/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netcoreapp2.1/ProcessPolyfill.cs
+++ b/src/Split/netcoreapp2.1/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netcoreapp2.2/Polyfill_Process.cs
+++ b/src/Split/netcoreapp2.2/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netcoreapp2.2/ProcessPolyfill.cs
+++ b/src/Split/netcoreapp2.2/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netcoreapp3.0/Polyfill_Process.cs
+++ b/src/Split/netcoreapp3.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -170,6 +173,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netcoreapp3.0/ProcessPolyfill.cs
+++ b/src/Split/netcoreapp3.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netcoreapp3.1/Polyfill_Process.cs
+++ b/src/Split/netcoreapp3.1/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -170,6 +173,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netcoreapp3.1/ProcessPolyfill.cs
+++ b/src/Split/netcoreapp3.1/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netstandard2.0/Polyfill_Process.cs
+++ b/src/Split/netstandard2.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netstandard2.0/ProcessPolyfill.cs
+++ b/src/Split/netstandard2.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/netstandard2.1/Polyfill_Process.cs
+++ b/src/Split/netstandard2.1/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/netstandard2.1/ProcessPolyfill.cs
+++ b/src/Split/netstandard2.1/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Split/uap10.0/Polyfill_Process.cs
+++ b/src/Split/uap10.0/Polyfill_Process.cs
@@ -3,9 +3,12 @@
 namespace Polyfills;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -179,6 +182,180 @@ static partial class Polyfill
 		}
 	}
 #endif
+	/// <summary>
+	/// Sends the specified POSIX signal to the associated process.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool Signal(this Process target, PosixSignal signal)
+	{
+		if (SignalHelper.IsWindows)
+		{
+			if (target.HasExited)
+			{
+				return false;
+			}
+			if ((int) signal != SignalHelper.SigKill)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			try
+			{
+				target.Kill();
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+		}
+		return SignalHelper.Send(target.Id, signal);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static ProcessExitStatus WaitForExitStatus(this Process target)
+	{
+		target.WaitForExit();
+		return ToExitStatus(target.ExitCode);
+	}
+	/// <summary>
+	/// Instructs the Process component to wait up to <paramref name="timeout"/> for the associated process to exit,
+	/// and returns a value indicating whether it exited.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static bool TryWaitForExitStatus(this Process target, TimeSpan timeout, [NotNullWhen(true)] out ProcessExitStatus? exitStatus)
+	{
+		var milliseconds = ToTimeoutMilliseconds(timeout);
+		if (!target.WaitForExit(milliseconds))
+		{
+			exitStatus = null;
+			return false;
+		}
+		exitStatus = ToExitStatus(target.ExitCode);
+		return true;
+	}
+	/// <summary>
+	/// Instructs the Process component to wait for the associated process to exit, or for the
+	/// <paramref name="cancellationToken"/> to be canceled, and returns its exit status.
+	/// </summary>
+	[SupportedOSPlatform("maccatalyst")]
+	[UnsupportedOSPlatform("ios")]
+	[UnsupportedOSPlatform("tvos")]
+	public static async Task<ProcessExitStatus> WaitForExitStatusAsync(this Process target, CancellationToken cancellationToken = default)
+	{
+		await target.WaitForExitAsync(cancellationToken);
+		return ToExitStatus(target.ExitCode);
+	}
+	static ProcessExitStatus ToExitStatus(int exitCode)
+	{
+		if (!SignalHelper.IsWindows)
+		{
+			var signal = SignalHelper.ToPosixSignal(exitCode - 128);
+			if (signal != null)
+			{
+				return new(exitCode, canceled: false, signal);
+			}
+		}
+		return new(exitCode, canceled: false);
+	}
+	static int ToTimeoutMilliseconds(TimeSpan timeout)
+	{
+		var milliseconds = (long) timeout.TotalMilliseconds;
+		if (milliseconds < -1 ||
+			milliseconds > int.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be -1 milliseconds, or between 0 and Int32.MaxValue milliseconds.");
+		}
+		return (int) milliseconds;
+	}
+	[ExcludeFromCodeCoverage]
+	[DebuggerNonUserCode]
+#if PolyUseEmbeddedAttribute
+	[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+#endif
+	static class SignalHelper
+	{
+		/// <summary>
+		/// The value of PosixSignal.SIGKILL, which was added in net11 and so cannot be named on earlier target frameworks.
+		/// </summary>
+		public const int SigKill = -11;
+		const int ESRCH = 3;
+#if FeatureRuntimeInformation
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		static readonly bool isBsd = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+									 RuntimeInformation.OSDescription.ToLower().Contains("bsd");
+#else
+		public static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool isBsd = Environment.OSVersion.Platform == PlatformID.MacOSX;
+#endif
+		public static bool Send(int processId, PosixSignal signal)
+		{
+			var number = ToSignalNumber(signal);
+			if (number == 0)
+			{
+				throw new PlatformNotSupportedException();
+			}
+			if (kill(processId, number) == 0)
+			{
+				return true;
+			}
+			var error = Marshal.GetLastWin32Error();
+			if (error == ESRCH)
+			{
+				return false;
+			}
+			throw new Win32Exception(error);
+		}
+		static int ToSignalNumber(PosixSignal signal)
+		{
+			var value = (int) signal;
+			if (value > 0)
+			{
+				return value;
+			}
+			return value switch
+			{
+				-1 => 1, // SIGHUP
+				-2 => 2, // SIGINT
+				-3 => 3, // SIGQUIT
+				-4 => 15, // SIGTERM
+				-5 => isBsd ? 20 : 17, // SIGCHLD
+				-6 => isBsd ? 19 : 18, // SIGCONT
+				-7 => 28, // SIGWINCH
+				-8 => 21, // SIGTTIN
+				-9 => 22, // SIGTTOU
+				-10 => isBsd ? 18 : 20, // SIGTSTP
+				SigKill => 9, // SIGKILL
+				_ => 0
+			};
+		}
+		public static PosixSignal? ToPosixSignal(int number) =>
+			number switch
+			{
+				1 => PosixSignal.SIGHUP,
+				2 => PosixSignal.SIGINT,
+				3 => PosixSignal.SIGQUIT,
+				9 => (PosixSignal) SigKill,
+				15 => PosixSignal.SIGTERM,
+				17 => isBsd ? null : PosixSignal.SIGCHLD,
+				18 => isBsd ? PosixSignal.SIGTSTP : PosixSignal.SIGCONT,
+				19 => isBsd ? PosixSignal.SIGCONT : null,
+				20 => isBsd ? PosixSignal.SIGCHLD : PosixSignal.SIGTSTP,
+				21 => PosixSignal.SIGTTIN,
+				22 => PosixSignal.SIGTTOU,
+				28 => PosixSignal.SIGWINCH,
+				_ => null
+			};
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		static extern int kill(int pid, int signal);
+	}
 	static void WaitForExitOrThrow(Process target, TimeSpan? timeout)
 	{
 		if (timeout is { } value)

--- a/src/Split/uap10.0/ProcessPolyfill.cs
+++ b/src/Split/uap10.0/ProcessPolyfill.cs
@@ -22,7 +22,7 @@ static partial class Polyfill
 		{
 			using var process = StartOrThrow(startInfo);
 			WaitForExitOrThrow(process, timeout);
-			return new(process.ExitCode, canceled: false);
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -64,7 +64,11 @@ static partial class Polyfill
 				{
 				}
 			}
-			return new(canceled ? -1 : process.ExitCode, canceled);
+			if (canceled)
+			{
+				return new(-1, canceled: true);
+			}
+			return ToExitStatus(process.ExitCode);
 		}
 		/// <summary>
 		/// Asynchronously starts the process described by <paramref name="fileName"/> and <paramref name="arguments"/>, waits for it to exit, and returns the exit status.
@@ -94,7 +98,7 @@ static partial class Polyfill
 			var stderrTask = process.StandardError.ReadToEndAsync();
 			var pid = process.Id;
 			WaitForExitOrThrow(process, timeout);
-			var status = new ProcessExitStatus(process.ExitCode, canceled: false);
+			var status = ToExitStatus(process.ExitCode);
 			return new(status, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult(), pid);
 		}
 		/// <summary>
@@ -135,7 +139,7 @@ static partial class Polyfill
 				{
 				}
 			}
-			var status = new ProcessExitStatus(canceled ? -1 : process.ExitCode, canceled);
+			var status = canceled ? new ProcessExitStatus(-1, canceled: true) : ToExitStatus(process.ExitCode);
 			return new(status, await stdoutTask, await stderrTask, pid);
 		}
 		/// <summary>

--- a/src/Tests/PolyfillTests_Process.cs
+++ b/src/Tests/PolyfillTests_Process.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 
 partial class PolyfillTests
@@ -287,5 +288,124 @@ partial class PolyfillTests
         await Assert.That(output.StandardOutput).IsEqualTo("out");
         await Assert.That(output.StandardError).IsEqualTo("err");
         await Assert.That(output.ProcessId).IsEqualTo(1234);
+    }
+
+    [Test]
+    public async Task Process_WaitForExitStatus()
+    {
+        using var process = StartVersion();
+        var status = process.WaitForExitStatus();
+        await Assert.That(status.ExitCode).IsEqualTo(0);
+        await Assert.That(status.Canceled).IsFalse();
+        await Assert.That(status.Signal).IsNull();
+    }
+
+    [Test]
+    public async Task Process_TryWaitForExitStatus()
+    {
+        using var process = StartVersion();
+        var exited = process.TryWaitForExitStatus(TimeSpan.FromMinutes(1), out var status);
+        await Assert.That(exited).IsTrue();
+        await Assert.That(status!.ExitCode).IsEqualTo(0);
+        await Assert.That(status.Canceled).IsFalse();
+        await Assert.That(status.Signal).IsNull();
+    }
+
+    [Test]
+    public async Task Process_TryWaitForExitStatus_Timeout()
+    {
+        var process = Process.GetCurrentProcess();
+        var exited = process.TryWaitForExitStatus(TimeSpan.Zero, out var status);
+        await Assert.That(exited).IsFalse();
+        await Assert.That(status).IsNull();
+    }
+
+    [Test]
+    public async Task Process_TryWaitForExitStatus_NegativeTimeout()
+    {
+        var process = Process.GetCurrentProcess();
+        await Assert.That(() => { process.TryWaitForExitStatus(TimeSpan.FromMilliseconds(-2), out _); })
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Process_WaitForExitStatusAsync()
+    {
+        using var process = StartVersion();
+        var status = await process.WaitForExitStatusAsync();
+        await Assert.That(status.ExitCode).IsEqualTo(0);
+        await Assert.That(status.Canceled).IsFalse();
+        await Assert.That(status.Signal).IsNull();
+    }
+
+    [Test]
+    public async Task Process_WaitForExitStatusAsync_Canceled()
+    {
+        using var cancelSource = new CancelSource();
+        cancelSource.Cancel();
+        var process = Process.GetCurrentProcess();
+        await Assert.That(async () => await process.WaitForExitStatusAsync(cancelSource.Token))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task Process_Signal()
+    {
+        var process = Process.GetCurrentProcess();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Windows supports only SIGKILL, which cannot be named before net11
+            await Assert.That(() => { process.Signal(PosixSignal.SIGCONT); })
+                .Throws<PlatformNotSupportedException>();
+        }
+        else
+        {
+            // SIGCONT to a process that is already running is a no-op
+            await Assert.That(process.Signal(PosixSignal.SIGCONT)).IsTrue();
+        }
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    [Test]
+    public async Task Process_WaitForExitStatus_TerminatedBySignal()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        using var process = Process.Start(
+            new ProcessStartInfo
+            {
+                FileName = "sleep",
+                Arguments = "30",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            })!;
+
+        var signaled = process.Signal(PosixSignal.SIGTERM);
+        await Assert.That(signaled).IsTrue();
+
+        var status = process.WaitForExitStatus();
+        // Unix reports termination by a signal as an exit code of 128 plus the signal number
+        await Assert.That(status.ExitCode).IsEqualTo(143);
+        await Assert.That(status.Signal).IsEqualTo(PosixSignal.SIGTERM);
+        await Assert.That(status.Canceled).IsFalse();
+    }
+
+    static Process StartVersion()
+    {
+        var process = Process.Start(
+            new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = "--version",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+            })!;
+        // drain the pipe so the child cannot block on a full buffer
+        process.StandardOutput.ReadToEnd();
+        return process;
     }
 }


### PR DESCRIPTION
Adds the four Process APIs from the .NET 11 RC1 release notes:

* bool Signal(PosixSignal)
* ProcessExitStatus WaitForExitStatus()
* bool TryWaitForExitStatus(TimeSpan, out ProcessExitStatus?)
* Task<ProcessExitStatus> WaitForExitStatusAsync(CancellationToken)

Signal uses kill(2) on Unix, returning false on ESRCH and throwing Win32Exception otherwise. On Windows only SIGKILL is supported and maps to Process.Kill, matching net11. Signal numbers differ between Linux and BSD/macOS for SIGCHLD, SIGCONT and SIGTSTP, so the mapping branches on the platform.

The terminating signal is derived from the exit code, which Unix reports as 128 plus the signal number, rather than from the raw wait status. A process that exits normally with a code in that range is therefore reported as signal terminated.

PosixSignal.SIGKILL was added in net11, so it is not added to the polyfilled enum: that enum only covers pre-net6, so the member would compile there and fail to compile on net6 through net10, where the BCL owns the type. Signal compares the value numerically, so it works if the member is ever added.

Run, RunAsync, RunAndCaptureText and RunAndCaptureTextAsync now share the same exit status conversion, so they populate Signal as net11 does.