### PR TITLE
Add net11 Process.ReadAllLines

### DIFF
--- a/apiCount.include.md
+++ b/apiCount.include.md
@@ -1,4 +1,4 @@
-**API count: 1072**
+**API count: 1073**
 
 ### Per Target Framework
 
@@ -16,13 +16,13 @@
 | `netcoreapp2.0` | 923 |
 | `netcoreapp2.1` | 864 |
 | `netcoreapp2.2` | 864 |
-| `netcoreapp3.0` | 819 |
-| `netcoreapp3.1` | 818 |
-| `net5.0` | 690 |
-| `net6.0` | 591 |
-| `net7.0` | 438 |
-| `net8.0` | 317 |
-| `net9.0` | 223 |
-| `net10.0` | 169 |
+| `netcoreapp3.0` | 825 |
+| `netcoreapp3.1` | 824 |
+| `net5.0` | 696 |
+| `net6.0` | 597 |
+| `net7.0` | 444 |
+| `net8.0` | 323 |
+| `net9.0` | 229 |
+| `net10.0` | 175 |
 | `net11.0` | 58 |
 | `uap10.0` | 990 |

--- a/api_list.include.md
+++ b/api_list.include.md
@@ -811,6 +811,8 @@
  * `void Kill(bool)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-11.0#system-diagnostics-process-kill(system-boolean))
  * `(byte[] StandardOutput, byte[] StandardError) ReadAllBytes(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readallbytes?view=net-11.0)
  * `Task<(byte[] StandardOutput, byte[] StandardError)> ReadAllBytesAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readallbytesasync?view=net-11.0)
+ * `IEnumerable<ProcessOutputLine> ReadAllLines(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllines?view=net-11.0)
+   * Note: The timeout is measured from the point enumeration starts, since the returned sequence is lazy.
  * `IAsyncEnumerable<ProcessOutputLine> ReadAllLinesAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllinesasync?view=net-11.0)
  * `(string StandardOutput, string StandardError) ReadAllText(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltext?view=net-11.0)
  * `Task<(string StandardOutput, string StandardError)> ReadAllTextAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltextasync?view=net-11.0)

--- a/assemblySize.include.md
+++ b/assemblySize.include.md
@@ -14,15 +14,15 @@
 | netcoreapp2.0  |          9.0KB |       343.0KB |  +334.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp2.1  |          9.0KB |       323.0KB |  +314.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp2.2  |          9.0KB |       323.0KB |  +314.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.0  |          9.5KB |       317.0KB |  +307.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.1  |          9.5KB |       315.5KB |  +306.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net5.0         |          9.5KB |       279.5KB |  +270.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net6.0         |         10.0KB |       221.0KB |  +211.0KB |   +10.0KB |             +7.0KB |           +512bytes |      +3.5KB |
-| net7.0         |         10.0KB |       183.5KB |  +173.5KB |   +12.0KB |             +8.5KB |              +3.5KB |      +6.0KB |
-| net8.0         |          9.5KB |       156.5KB |  +147.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net9.0         |          9.5KB |       109.5KB |  +100.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net10.0        |         10.0KB |        87.5KB |   +77.5KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
-| net11.0        |         10.0KB |        20.5KB |   +10.5KB |    +9.5KB |          +512bytes |              +1.0KB |      +4.0KB |
+| netcoreapp3.0  |          9.5KB |       319.0KB |  +309.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netcoreapp3.1  |          9.5KB |       317.5KB |  +308.0KB |    +8.5KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net5.0         |          9.5KB |       281.5KB |  +272.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net6.0         |         10.0KB |       223.0KB |  +213.0KB |    +9.5KB |             +7.0KB |           +512bytes |      +3.5KB |
+| net7.0         |         10.0KB |       188.0KB |  +178.0KB |    +9.5KB |             +6.0KB |              +1.0KB |      +3.5KB |
+| net8.0         |          9.5KB |       158.5KB |  +149.0KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
+| net9.0         |          9.5KB |       111.5KB |  +102.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net10.0        |         10.0KB |        89.5KB |   +79.5KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
+| net11.0        |         10.0KB |        21.0KB |   +11.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 
 
 ### Assembly Sizes with EmbedUntrackedSources
@@ -41,12 +41,12 @@
 | netcoreapp2.0  |          9.0KB |       503.8KB |  +494.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.1  |          9.0KB |       471.5KB |  +462.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.2  |          9.0KB |       471.5KB |  +462.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.0  |          9.5KB |       457.4KB |  +447.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.1  |          9.5KB |       455.9KB |  +446.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net5.0         |          9.5KB |       401.8KB |  +392.3KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net6.0         |         10.0KB |       323.3KB |  +313.3KB |   +17.7KB |             +8.7KB |              +1.1KB |      +4.2KB |
-| net7.0         |         10.0KB |       267.5KB |  +257.5KB |   +19.6KB |             +9.9KB |              +4.1KB |      +6.7KB |
-| net8.0         |          9.5KB |       226.7KB |  +217.2KB |   +16.0KB |          +299bytes |              +1.1KB |      +4.2KB |
-| net9.0         |          9.5KB |       158.5KB |  +149.0KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
-| net10.0        |         10.0KB |       127.8KB |  +117.8KB |   +16.0KB |                    |              +1.1KB |      +3.7KB |
-| net11.0        |         10.0KB |        30.4KB |   +20.4KB |   +17.0KB |          +512bytes |              +1.6KB |      +4.7KB |
+| netcoreapp3.0  |          9.5KB |       460.8KB |  +451.3KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netcoreapp3.1  |          9.5KB |       459.2KB |  +449.7KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net5.0         |          9.5KB |       405.1KB |  +395.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net6.0         |         10.0KB |       326.7KB |  +316.7KB |   +17.2KB |             +8.7KB |              +1.1KB |      +4.2KB |
+| net7.0         |         10.0KB |       273.4KB |  +263.4KB |   +17.1KB |             +7.4KB |              +1.6KB |      +4.2KB |
+| net8.0         |          9.5KB |       230.0KB |  +220.5KB |   +16.0KB |          +299bytes |              +1.1KB |      +3.7KB |
+| net9.0         |          9.5KB |       161.9KB |  +152.4KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
+| net10.0        |         10.0KB |       131.2KB |  +121.2KB |   +16.0KB |                    |              +1.1KB |      +3.7KB |
+| net11.0        |         10.0KB |        30.9KB |   +20.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The package targets `netstandard2.0` and is designed to support the following ru
  * `uap10`
 
 
-**API count: 1072**<!-- include: apiCount. path: /apiCount.include.md -->
+**API count: 1073**<!-- include: apiCount. path: /apiCount.include.md -->
 
 ### Per Target Framework
 
@@ -31,14 +31,14 @@ The package targets `netstandard2.0` and is designed to support the following ru
 | `netcoreapp2.0` | 923 |
 | `netcoreapp2.1` | 864 |
 | `netcoreapp2.2` | 864 |
-| `netcoreapp3.0` | 819 |
-| `netcoreapp3.1` | 818 |
-| `net5.0` | 690 |
-| `net6.0` | 591 |
-| `net7.0` | 438 |
-| `net8.0` | 317 |
-| `net9.0` | 223 |
-| `net10.0` | 169 |
+| `netcoreapp3.0` | 825 |
+| `netcoreapp3.1` | 824 |
+| `net5.0` | 696 |
+| `net6.0` | 597 |
+| `net7.0` | 444 |
+| `net8.0` | 323 |
+| `net9.0` | 229 |
+| `net10.0` | 175 |
 | `net11.0` | 58 |
 | `uap10.0` | 990 |
 <!-- endInclude -->
@@ -108,15 +108,15 @@ This project uses features from the newest stable SDK and C# language. As such c
 | netcoreapp2.0  |          9.0KB |       343.0KB |  +334.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp2.1  |          9.0KB |       323.0KB |  +314.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp2.2  |          9.0KB |       323.0KB |  +314.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.0  |          9.5KB |       317.0KB |  +307.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
-| netcoreapp3.1  |          9.5KB |       315.5KB |  +306.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net5.0         |          9.5KB |       279.5KB |  +270.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
-| net6.0         |         10.0KB |       221.0KB |  +211.0KB |   +10.0KB |             +7.0KB |           +512bytes |      +3.5KB |
-| net7.0         |         10.0KB |       183.5KB |  +173.5KB |   +12.0KB |             +8.5KB |              +3.5KB |      +6.0KB |
-| net8.0         |          9.5KB |       156.5KB |  +147.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net9.0         |          9.5KB |       109.5KB |  +100.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
-| net10.0        |         10.0KB |        87.5KB |   +77.5KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
-| net11.0        |         10.0KB |        20.5KB |   +10.5KB |    +9.5KB |          +512bytes |              +1.0KB |      +4.0KB |
+| netcoreapp3.0  |          9.5KB |       319.0KB |  +309.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| netcoreapp3.1  |          9.5KB |       317.5KB |  +308.0KB |    +8.5KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net5.0         |          9.5KB |       281.5KB |  +272.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
+| net6.0         |         10.0KB |       223.0KB |  +213.0KB |    +9.5KB |             +7.0KB |           +512bytes |      +3.5KB |
+| net7.0         |         10.0KB |       188.0KB |  +178.0KB |    +9.5KB |             +6.0KB |              +1.0KB |      +3.5KB |
+| net8.0         |          9.5KB |       158.5KB |  +149.0KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
+| net9.0         |          9.5KB |       111.5KB |  +102.0KB |    +8.5KB |                    |           +512bytes |      +3.5KB |
+| net10.0        |         10.0KB |        89.5KB |   +79.5KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
+| net11.0        |         10.0KB |        21.0KB |   +11.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
 
 
 ### Assembly Sizes with EmbedUntrackedSources
@@ -135,15 +135,15 @@ This project uses features from the newest stable SDK and C# language. As such c
 | netcoreapp2.0  |          9.0KB |       503.8KB |  +494.8KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.1  |          9.0KB |       471.5KB |  +462.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp2.2  |          9.0KB |       471.5KB |  +462.5KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.0  |          9.5KB |       457.4KB |  +447.9KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
-| netcoreapp3.1  |          9.5KB |       455.9KB |  +446.4KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net5.0         |          9.5KB |       401.8KB |  +392.3KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
-| net6.0         |         10.0KB |       323.3KB |  +313.3KB |   +17.7KB |             +8.7KB |              +1.1KB |      +4.2KB |
-| net7.0         |         10.0KB |       267.5KB |  +257.5KB |   +19.6KB |             +9.9KB |              +4.1KB |      +6.7KB |
-| net8.0         |          9.5KB |       226.7KB |  +217.2KB |   +16.0KB |          +299bytes |              +1.1KB |      +4.2KB |
-| net9.0         |          9.5KB |       158.5KB |  +149.0KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
-| net10.0        |         10.0KB |       127.8KB |  +117.8KB |   +16.0KB |                    |              +1.1KB |      +3.7KB |
-| net11.0        |         10.0KB |        30.4KB |   +20.4KB |   +17.0KB |          +512bytes |              +1.6KB |      +4.7KB |
+| netcoreapp3.0  |          9.5KB |       460.8KB |  +451.3KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| netcoreapp3.1  |          9.5KB |       459.2KB |  +449.7KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net5.0         |          9.5KB |       405.1KB |  +395.6KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
+| net6.0         |         10.0KB |       326.7KB |  +316.7KB |   +17.2KB |             +8.7KB |              +1.1KB |      +4.2KB |
+| net7.0         |         10.0KB |       273.4KB |  +263.4KB |   +17.1KB |             +7.4KB |              +1.6KB |      +4.2KB |
+| net8.0         |          9.5KB |       230.0KB |  +220.5KB |   +16.0KB |          +299bytes |              +1.1KB |      +3.7KB |
+| net9.0         |          9.5KB |       161.9KB |  +152.4KB |   +16.0KB |                    |              +1.1KB |      +4.2KB |
+| net10.0        |         10.0KB |       131.2KB |  +121.2KB |   +16.0KB |                    |              +1.1KB |      +3.7KB |
+| net11.0        |         10.0KB |        30.9KB |   +20.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
 <!-- endInclude -->
 
 
@@ -1426,6 +1426,8 @@ The class `Polyfill` includes the following extension methods:
  * `void Kill(bool)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-11.0#system-diagnostics-process-kill(system-boolean))
  * `(byte[] StandardOutput, byte[] StandardError) ReadAllBytes(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readallbytes?view=net-11.0)
  * `Task<(byte[] StandardOutput, byte[] StandardError)> ReadAllBytesAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readallbytesasync?view=net-11.0)
+ * `IEnumerable<ProcessOutputLine> ReadAllLines(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllines?view=net-11.0)
+   * Note: The timeout is measured from the point enumeration starts, since the returned sequence is lazy.
  * `IAsyncEnumerable<ProcessOutputLine> ReadAllLinesAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllinesasync?view=net-11.0)
  * `(string StandardOutput, string StandardError) ReadAllText(TimeSpan?)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltext?view=net-11.0)
  * `Task<(string StandardOutput, string StandardError)> ReadAllTextAsync(CancellationToken)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalltextasync?view=net-11.0)

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -1418,6 +1418,17 @@ class Consume
         (outBytes, errBytes) = await process.ReadAllBytesAsync(CancellationToken.None);
 #endif
 
+        foreach (ProcessOutputLine syncLine in process.ReadAllLines())
+        {
+            _ = syncLine.Content;
+            _ = syncLine.StandardError;
+        }
+
+        foreach (ProcessOutputLine syncLine in process.ReadAllLines(TimeSpan.FromSeconds(1)))
+        {
+            _ = syncLine.Content;
+        }
+
 #if FeatureAsyncInterfaces
         await foreach (var line in process.ReadAllLinesAsync(CancellationToken.None))
         {

--- a/src/Polyfill/Polyfill_Process.cs
+++ b/src/Polyfill/Polyfill_Process.cs
@@ -135,6 +135,111 @@ static partial class Polyfill
     }
 #endif
 
+    /// <summary>
+    /// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+    /// </summary>
+    //Link: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.readalllines?view=net-11.0
+    //Note: The timeout is measured from the point enumeration starts, since the returned sequence is lazy.
+    public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+    {
+        var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+        var signal = new SemaphoreSlim(0);
+        var sync = new object();
+        var stdoutDone = false;
+        var stderrDone = false;
+
+        DataReceivedEventHandler outHandler = (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                lock (sync) stdoutDone = true;
+            }
+            else
+            {
+                queue.Enqueue(new(e.Data, false));
+            }
+            signal.Release();
+        };
+        DataReceivedEventHandler errHandler = (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                lock (sync) stderrDone = true;
+            }
+            else
+            {
+                queue.Enqueue(new(e.Data, true));
+            }
+            signal.Release();
+        };
+
+        target.OutputDataReceived += outHandler;
+        target.ErrorDataReceived += errHandler;
+        target.BeginOutputReadLine();
+        target.BeginErrorReadLine();
+
+        var watch = Stopwatch.StartNew();
+
+        try
+        {
+            while (true)
+            {
+                if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+                {
+                    throw new TimeoutException("The process did not exit within the specified timeout.");
+                }
+
+                while (queue.TryDequeue(out var line))
+                {
+                    yield return line;
+                }
+
+                bool done;
+                lock (sync)
+                {
+                    done = stdoutDone && stderrDone;
+                }
+
+                if (done)
+                {
+                    while (queue.TryDequeue(out var line))
+                    {
+                        yield return line;
+                    }
+
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            target.OutputDataReceived -= outHandler;
+            target.ErrorDataReceived -= errHandler;
+            signal.Dispose();
+        }
+    }
+
+    static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+    {
+        if (timeout is not { } value)
+        {
+            return Timeout.Infinite;
+        }
+
+        var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+        if (remaining <= 0)
+        {
+            return 0;
+        }
+
+        if (remaining > int.MaxValue)
+        {
+            return Timeout.Infinite;
+        }
+
+        return (int) remaining;
+    }
+
 #if FeatureAsyncInterfaces
     /// <summary>
     /// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net10.0/Polyfill_Process.cs
+++ b/src/Split/net10.0/Polyfill_Process.cs
@@ -63,6 +63,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net461/Polyfill_Process.cs
+++ b/src/Split/net461/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net462/Polyfill_Process.cs
+++ b/src/Split/net462/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net47/Polyfill_Process.cs
+++ b/src/Split/net47/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net471/Polyfill_Process.cs
+++ b/src/Split/net471/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net472/Polyfill_Process.cs
+++ b/src/Split/net472/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net48/Polyfill_Process.cs
+++ b/src/Split/net48/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net481/Polyfill_Process.cs
+++ b/src/Split/net481/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net5.0/Polyfill_Process.cs
+++ b/src/Split/net5.0/Polyfill_Process.cs
@@ -63,6 +63,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net6.0/Polyfill_Process.cs
+++ b/src/Split/net6.0/Polyfill_Process.cs
@@ -63,6 +63,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net7.0/Polyfill_Process.cs
+++ b/src/Split/net7.0/Polyfill_Process.cs
@@ -63,6 +63,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net8.0/Polyfill_Process.cs
+++ b/src/Split/net8.0/Polyfill_Process.cs
@@ -63,6 +63,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/net9.0/Polyfill_Process.cs
+++ b/src/Split/net9.0/Polyfill_Process.cs
@@ -63,6 +63,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netcoreapp2.0/Polyfill_Process.cs
+++ b/src/Split/netcoreapp2.0/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netcoreapp2.1/Polyfill_Process.cs
+++ b/src/Split/netcoreapp2.1/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netcoreapp2.2/Polyfill_Process.cs
+++ b/src/Split/netcoreapp2.2/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netcoreapp3.0/Polyfill_Process.cs
+++ b/src/Split/netcoreapp3.0/Polyfill_Process.cs
@@ -100,6 +100,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netcoreapp3.1/Polyfill_Process.cs
+++ b/src/Split/netcoreapp3.1/Polyfill_Process.cs
@@ -100,6 +100,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netstandard2.0/Polyfill_Process.cs
+++ b/src/Split/netstandard2.0/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/netstandard2.1/Polyfill_Process.cs
+++ b/src/Split/netstandard2.1/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Split/uap10.0/Polyfill_Process.cs
+++ b/src/Split/uap10.0/Polyfill_Process.cs
@@ -109,6 +109,96 @@ static partial class Polyfill
 		return (outMs.ToArray(), errMs.ToArray());
 	}
 #endif
+	/// <summary>
+	/// Reads the standard output and standard error of the process line-by-line, waiting for the process to exit.
+	/// </summary>
+	public static IEnumerable<ProcessOutputLine> ReadAllLines(this Process target, TimeSpan? timeout = default)
+	{
+		var queue = new System.Collections.Concurrent.ConcurrentQueue<ProcessOutputLine>();
+		var signal = new SemaphoreSlim(0);
+		var sync = new object();
+		var stdoutDone = false;
+		var stderrDone = false;
+		DataReceivedEventHandler outHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stdoutDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, false));
+			}
+			signal.Release();
+		};
+		DataReceivedEventHandler errHandler = (_, e) =>
+		{
+			if (e.Data is null)
+			{
+				lock (sync) stderrDone = true;
+			}
+			else
+			{
+				queue.Enqueue(new(e.Data, true));
+			}
+			signal.Release();
+		};
+		target.OutputDataReceived += outHandler;
+		target.ErrorDataReceived += errHandler;
+		target.BeginOutputReadLine();
+		target.BeginErrorReadLine();
+		var watch = Stopwatch.StartNew();
+		try
+		{
+			while (true)
+			{
+				if (!signal.Wait(RemainingMilliseconds(watch, timeout)))
+				{
+					throw new TimeoutException("The process did not exit within the specified timeout.");
+				}
+				while (queue.TryDequeue(out var line))
+				{
+					yield return line;
+				}
+				bool done;
+				lock (sync)
+				{
+					done = stdoutDone && stderrDone;
+				}
+				if (done)
+				{
+					while (queue.TryDequeue(out var line))
+					{
+						yield return line;
+					}
+					yield break;
+				}
+			}
+		}
+		finally
+		{
+			target.OutputDataReceived -= outHandler;
+			target.ErrorDataReceived -= errHandler;
+			signal.Dispose();
+		}
+	}
+	static int RemainingMilliseconds(Stopwatch watch, TimeSpan? timeout)
+	{
+		if (timeout is not { } value)
+		{
+			return Timeout.Infinite;
+		}
+		var remaining = value.TotalMilliseconds - watch.Elapsed.TotalMilliseconds;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+		if (remaining > int.MaxValue)
+		{
+			return Timeout.Infinite;
+		}
+		return (int) remaining;
+	}
 #if FeatureAsyncInterfaces
 	/// <summary>
 	/// Asynchronously reads the standard output and standard error of the process line-by-line, waiting for the process to exit.

--- a/src/Tests/PolyfillTests_Process.cs
+++ b/src/Tests/PolyfillTests_Process.cs
@@ -161,6 +161,45 @@ partial class PolyfillTests
     }
 
     [Test]
+    public async Task Process_ReadAllLines()
+    {
+        using var process = StartRedirected("--info");
+        var lines = process.ReadAllLines().ToList();
+        await Assert.That(lines.Count).IsGreaterThan(0);
+        await Assert.That(lines.Any(_ => !_.StandardError)).IsTrue();
+        await Assert.That(lines.All(_ => _.Content != null)).IsTrue();
+        await Assert.That(process.HasExited).IsTrue();
+    }
+
+    [Test]
+    public async Task Process_ReadAllLines_Timeout()
+    {
+        using var process = StartRedirected("--version");
+        var lines = process.ReadAllLines(TimeSpan.FromMinutes(1)).ToList();
+        await Assert.That(lines.Count).IsGreaterThan(0);
+        var first = lines.First(_ => !_.StandardError);
+        await Assert.That(first.Content.Length).IsGreaterThan(0);
+    }
+
+    static Process StartRedirected(string arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            }
+        };
+        process.Start();
+        return process;
+    }
+
+    [Test]
     public async Task Process_Run()
     {
         var status = Process.Run("dotnet", new[] { "--info" });


### PR DESCRIPTION
Adds the synchronous counterpart to the already polyfilled `ReadAllLinesAsync`:

```csharp
IEnumerable<ProcessOutputLine> ReadAllLines(TimeSpan? timeout = null)
```

API count 1072 to 1073. This was the last item outstanding from the net11 RC1 sweep.

### Semantics

Taken from net11 by driving a child process that writes to both streams with delays between them, rather than assumed:

* the sequence is **lazy**. The call returned in 0ms and lines were yielded at 51ms, 755ms and 1458ms as the child produced them, rather than being collected first
* standard output and standard error are **interleaved in arrival order**
* exceeding the timeout throws `TimeoutException`, matching `WaitForExitOrThrow` and the other synchronous helpers on `Process`
* a process whose output is not redirected throws `InvalidOperationException`

### Implementation

An iterator over the same `ConcurrentQueue` and `SemaphoreSlim` arrangement `ReadAllLinesAsync` already uses, with a blocking wait bounded by the remaining timeout.

Because an iterator body does not run until it is enumerated, the timeout is measured from the point enumeration starts rather than from the call. Recorded as a `//Note:`.

### One gap in the tests

Nothing asserts the `TimeoutException` path. Provoking it needs a child that stays quiet for a known interval, and every candidate available to the test project either exits promptly or makes the assertion depend on timing, which would be flaky on CI. The path was exercised by hand against net11 with a purpose built child instead. For the same reason there is no test asserting laziness, though that was verified the same way.

The timeout parameter is still covered, with a value large enough not to fire, so the remaining-time arithmetic is exercised.

### Verification

* Solution builds clean in Release. `Consume` builds clean in Debug across all 22 target frameworks.
* Tests green on net11.0 (1672), net462 (1638), net8.0 (1669) and net10.0 (1672), plus `PublicTests`, `EmbeddedTests`, `UnsafeTests`, `NoRefsTests` and `NoExtrasTests`.
* Since these tests start real processes, the three new ones were run repeatedly on both net11.0 and net462 to check for timing flakiness. No failures.
