### PR TITLE
Probe the net9 Uri unescape bug rather than infer it from the target framework

### DIFF
--- a/src/Tests/UriPolyfillTests.cs
+++ b/src/Tests/UriPolyfillTests.cs
@@ -108,19 +108,23 @@ public class UriPolyfillTests
         }
     }
 
-    // net9.0 and net10.0 throw ArgumentOutOfRangeException instead of returning false when the
-    // destination cannot hold the literal text preceding the first escape sequence. Fixed in
-    // net11, and the polyfill behaves the way net11 does.
     [Test]
     public async Task TryUnescapeDataString_DestinationSmallerThanLiteralPrefix()
     {
-#if NET9_0_OR_GREATER && !NET11_0_OR_GREATER
-        await Assert.That(() => TryUnescape("abc%20def", 2)).Throws<ArgumentOutOfRangeException>();
-#else
+#if !NET9_0_OR_GREATER || NET11_0_OR_GREATER
+        // only net9.0 and net10.0 are allowed to throw here
+        await Assert.That(throwsOnShortDestination).IsFalse();
+#endif
+
+        if (throwsOnShortDestination)
+        {
+            await Assert.That(() => TryUnescape("abc%20def", 2)).Throws<ArgumentOutOfRangeException>();
+            return;
+        }
+
         var result = TryUnescape("abc%20def", 2);
         await Assert.That(result.Succeeded).IsFalse();
         await Assert.That(result.Written).IsEqualTo(0);
-#endif
     }
 
     // unescaping only ever shrinks, so a destination that overlaps the source is safe
@@ -139,13 +143,35 @@ public class UriPolyfillTests
 
     static int SmallestTestableSize(string sample)
     {
-#if NET9_0_OR_GREATER && !NET11_0_OR_GREATER
+        if (!throwsOnShortDestination)
+        {
+            return 0;
+        }
+
         // skip the sizes covered by TryUnescapeDataString_DestinationSmallerThanLiteralPrefix
         var index = sample.IndexOf('%');
         return index < 0 ? 0 : index;
-#else
-        return 0;
-#endif
+    }
+
+    // net9.0 and net10.0 shipped Uri.TryUnescapeDataString throwing ArgumentOutOfRangeException
+    // instead of returning false when the destination cannot hold the literal text preceding the
+    // first escape sequence (dotnet/runtime#124654, fixed for net11 by dotnet/runtime#124655).
+    // The backport to release/10.0, dotnet/runtime#128610, was written and then deferred, so the
+    // behaviour is probed rather than inferred from the target framework: a serviced net9.0 or
+    // net10.0 runtime would otherwise turn these tests red. The polyfill never throws.
+    static bool throwsOnShortDestination = ProbeThrowsOnShortDestination();
+
+    static bool ProbeThrowsOnShortDestination()
+    {
+        try
+        {
+            Uri.TryUnescapeDataString("abc%20def".AsSpan(), new char[2], out _);
+            return false;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return true;
+        }
     }
 
     // the spans stay inside these helpers, so nothing ref struct shaped has to live across an await


### PR DESCRIPTION
Follow-up to #595. Test-only; no change to shipped source, so `api_list` and the API count are untouched.

### The problem

#595 pinned the known BCL bug with a compile-time guard:

```csharp
#if NET9_0_OR_GREATER && !NET11_0_OR_GREATER
    await Assert.That(() => TryUnescape("abc%20def", 2)).Throws<ArgumentOutOfRangeException>();
#else
    ...assert it returns false
#endif
```

That asserts a property of the *runtime*, using the *target framework* as the proxy. It holds today, but it is a bet that neither net9.0 nor net10.0 is ever serviced with the fix — and [dotnet/runtime#128610](https://github.com/dotnet/runtime/pull/128610) is a fully written backport to `release/10.0` that was **deferred, not rejected**:

> I looked through the usages of this new API on GitHub … and none would be impacted by this particular bug. We'll wait with servicing previous releases until we see more real world impact.

net10.0 is LTS and in support until 2028-11-14, so that PR could be revived at any point. If it were, a patched net10.0 runtime would turn this repo's tests red for a reason that has nothing to do with Polyfill.

### The change

The behaviour is probed once, and both the sizing test and the dedicated test key off the result:

```csharp
static bool throwsOnShortDestination = ProbeThrowsOnShortDestination();

static bool ProbeThrowsOnShortDestination()
{
    try
    {
        Uri.TryUnescapeDataString("abc%20def".AsSpan(), new char[2], out _);
        return false;
    }
    catch (ArgumentOutOfRangeException)
    {
        return true;
    }
}
```

Relaxing this must not quietly relax it for the polyfill too, which is the thing these tests actually exist to check. So the strict assertion is kept everywhere it can be:

```csharp
#if !NET9_0_OR_GREATER || NET11_0_OR_GREATER
    // only net9.0 and net10.0 are allowed to throw here
    await Assert.That(throwsOnShortDestination).IsFalse();
#endif
```

net9.0 and net10.0 are the only frameworks permitted either outcome, and each is still asserted — a throw is asserted as a throw, and a non-throw is asserted to be `false` with zero written. Any third behaviour, including a different exception type, still fails. On a serviced net10.0 the sizing test would additionally start covering the destination sizes it currently skips, rather than staying silent.

### Verification

Solution clean in Release, tests green on net11.0 (1697), net10.0 (1697), net9.0 (1697), net8.0 (1694), net462 (1659), plus PublicTests, EmbeddedTests, UnsafeTests and NoRefsTests.
