### PR TITLE
Add the BitConverter Half members

### DIFF
--- a/apiCount.include.md
+++ b/apiCount.include.md
@@ -1,4 +1,4 @@
-**API count: 1139**
+**API count: 1147**
 
 ### Per Target Framework
 
@@ -18,7 +18,7 @@
 | `netcoreapp2.2` | 898 |
 | `netcoreapp3.0` | 859 |
 | `netcoreapp3.1` | 858 |
-| `net5.0` | 728 |
+| `net5.0` | 736 |
 | `net6.0` | 629 |
 | `net7.0` | 488 |
 | `net8.0` | 367 |

--- a/api_list.include.md
+++ b/api_list.include.md
@@ -93,14 +93,26 @@
 #### BitConverter
 
  * `ulong DoubleToUInt64Bits(double)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.doubletouint64bits?view=net-11.0)
+ * `byte[] GetBytes(Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-half))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `byte[] GetBytes(Int128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-int128))
  * `byte[] GetBytes(UInt128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-uint128))
+ * `short HalfToInt16Bits(Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.halftoint16bits?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
+ * `ushort HalfToUInt16Bits(Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.halftouint16bits?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
+ * `Half Int16BitsToHalf(short)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.int16bitstohalf?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `float Int32BitsToSingle(int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.int32bitstosingle?view=net-11.0)
  * `int SingleToInt32Bits(float)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.singletoint32bits?view=net-11.0)
  * `uint SingleToUInt32Bits(float)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.singletouint32bits?view=net-11.0)
  * `bool ToBoolean(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toboolean?view=net-11.0#system-bitconverter-toboolean(system-readonlyspan((system-byte))))
  * `char ToChar(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tochar?view=net-11.0#system-bitconverter-tochar(system-readonlyspan((system-byte))))
  * `double ToDouble(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.todouble?view=net-11.0#system-bitconverter-todouble(system-readonlyspan((system-byte))))
+ * `Half ToHalf(byte[], int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tohalf?view=net-11.0#system-bitconverter-tohalf(system-byte()-system-int32))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
+ * `Half ToHalf(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tohalf?view=net-11.0#system-bitconverter-tohalf(system-readonlyspan((system-byte))))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `Int128 ToInt128(byte[], int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toint128?view=net-11.0#system-bitconverter-toint128(system-byte()-system-int32))
  * `Int128 ToInt128(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toint128?view=net-11.0#system-bitconverter-toint128(system-readonlyspan((system-byte))))
  * `short ToInt16(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toint16?view=net-11.0#system-bitconverter-toint16(system-readonlyspan((system-byte))))
@@ -116,6 +128,8 @@
  * `bool TryWriteBytes(Span<byte>, char)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-char))
  * `bool TryWriteBytes(Span<byte>, double)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-double))
  * `bool TryWriteBytes(Span<byte>, float)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-single))
+ * `bool TryWriteBytes(Span<byte>, Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-half))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `bool TryWriteBytes(Span<byte>, int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-int32))
  * `bool TryWriteBytes(Span<byte>, Int128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-int128))
  * `bool TryWriteBytes(Span<byte>, long)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-int64))
@@ -124,6 +138,8 @@
  * `bool TryWriteBytes(Span<byte>, UInt128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-uint128))
  * `bool TryWriteBytes(Span<byte>, ulong)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-uint64))
  * `bool TryWriteBytes(Span<byte>, ushort)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-uint16))
+ * `Half UInt16BitsToHalf(ushort)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint16bitstohalf?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `float UInt32BitsToSingle(uint)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint32bitstosingle?view=net-11.0)
  * `double UInt64BitsToDouble(ulong)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint64bitstodouble?view=net-11.0)
 

--- a/assemblySize.include.md
+++ b/assemblySize.include.md
@@ -16,10 +16,10 @@
 | netcoreapp2.2  |          9.0KB |       330.5KB |  +321.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp3.0  |          9.5KB |       326.5KB |  +317.0KB |    +8.5KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp3.1  |          9.5KB |       324.5KB |  +315.0KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
-| net5.0         |          9.5KB |       288.5KB |  +279.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net5.0         |          9.5KB |       290.0KB |  +280.5KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
 | net6.0         |         10.0KB |       230.0KB |  +220.0KB |   +10.0KB |             +7.0KB |              +1.0KB |      +3.5KB |
 | net7.0         |         10.0KB |       199.0KB |  +189.0KB |    +9.0KB |             +5.5KB |           +512bytes |      +3.0KB |
-| net8.0         |          9.5KB |       169.0KB |  +159.5KB |    +8.0KB |                    |           +512bytes |      +3.0KB |
+| net8.0         |          9.5KB |       168.5KB |  +159.0KB |    +8.5KB |          +512bytes |              +1.0KB |      +3.5KB |
 | net9.0         |          9.5KB |       116.0KB |  +106.5KB |    +8.0KB |                    |           +512bytes |      +3.0KB |
 | net10.0        |         10.0KB |        93.5KB |   +83.5KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
 | net11.0        |         10.0KB |        21.0KB |   +11.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
@@ -43,10 +43,10 @@
 | netcoreapp2.2  |          9.0KB |       481.0KB |  +472.0KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp3.0  |          9.5KB |       470.3KB |  +460.8KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp3.1  |          9.5KB |       468.3KB |  +458.8KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| net5.0         |          9.5KB |       414.2KB |  +404.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net5.0         |          9.5KB |       416.3KB |  +406.8KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
 | net6.0         |         10.0KB |       335.8KB |  +325.8KB |   +17.7KB |             +8.7KB |              +1.6KB |      +4.2KB |
 | net7.0         |         10.0KB |       287.9KB |  +277.9KB |   +16.6KB |             +6.9KB |              +1.1KB |      +3.7KB |
-| net8.0         |          9.5KB |       244.1KB |  +234.6KB |   +15.5KB |          +299bytes |              +1.1KB |      +3.7KB |
+| net8.0         |          9.5KB |       243.6KB |  +234.1KB |   +16.0KB |          +811bytes |              +1.6KB |      +4.2KB |
 | net9.0         |          9.5KB |       167.6KB |  +158.1KB |   +15.5KB |                    |              +1.1KB |      +3.7KB |
 | net10.0        |         10.0KB |       136.1KB |  +126.1KB |   +16.0KB |                    |              +1.1KB |      +3.7KB |
 | net11.0        |         10.0KB |        30.9KB |   +20.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The package targets `netstandard2.0` and is designed to support the following ru
  * `uap10`
 
 
-**API count: 1139**<!-- include: apiCount. path: /apiCount.include.md -->
+**API count: 1147**<!-- include: apiCount. path: /apiCount.include.md -->
 
 ### Per Target Framework
 
@@ -33,7 +33,7 @@ The package targets `netstandard2.0` and is designed to support the following ru
 | `netcoreapp2.2` | 898 |
 | `netcoreapp3.0` | 859 |
 | `netcoreapp3.1` | 858 |
-| `net5.0` | 728 |
+| `net5.0` | 736 |
 | `net6.0` | 629 |
 | `net7.0` | 488 |
 | `net8.0` | 367 |
@@ -110,10 +110,10 @@ This project uses features from the newest stable SDK and C# language. As such c
 | netcoreapp2.2  |          9.0KB |       330.5KB |  +321.5KB |    +9.0KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp3.0  |          9.5KB |       326.5KB |  +317.0KB |    +8.5KB |             +6.5KB |              +9.0KB |     +13.5KB |
 | netcoreapp3.1  |          9.5KB |       324.5KB |  +315.0KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
-| net5.0         |          9.5KB |       288.5KB |  +279.0KB |    +9.0KB |             +6.5KB |              +9.0KB |     +14.0KB |
+| net5.0         |          9.5KB |       290.0KB |  +280.5KB |    +9.0KB |             +6.5KB |              +9.5KB |     +14.0KB |
 | net6.0         |         10.0KB |       230.0KB |  +220.0KB |   +10.0KB |             +7.0KB |              +1.0KB |      +3.5KB |
 | net7.0         |         10.0KB |       199.0KB |  +189.0KB |    +9.0KB |             +5.5KB |           +512bytes |      +3.0KB |
-| net8.0         |          9.5KB |       169.0KB |  +159.5KB |    +8.0KB |                    |           +512bytes |      +3.0KB |
+| net8.0         |          9.5KB |       168.5KB |  +159.0KB |    +8.5KB |          +512bytes |              +1.0KB |      +3.5KB |
 | net9.0         |          9.5KB |       116.0KB |  +106.5KB |    +8.0KB |                    |           +512bytes |      +3.0KB |
 | net10.0        |         10.0KB |        93.5KB |   +83.5KB |    +8.5KB |                    |           +512bytes |      +3.0KB |
 | net11.0        |         10.0KB |        21.0KB |   +11.0KB |    +9.0KB |                    |           +512bytes |      +3.5KB |
@@ -137,10 +137,10 @@ This project uses features from the newest stable SDK and C# language. As such c
 | netcoreapp2.2  |          9.0KB |       481.0KB |  +472.0KB |   +16.7KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp3.0  |          9.5KB |       470.3KB |  +460.8KB |   +16.2KB |             +8.2KB |             +13.9KB |     +18.9KB |
 | netcoreapp3.1  |          9.5KB |       468.3KB |  +458.8KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
-| net5.0         |          9.5KB |       414.2KB |  +404.7KB |   +16.7KB |             +8.2KB |             +13.9KB |     +19.4KB |
+| net5.0         |          9.5KB |       416.3KB |  +406.8KB |   +16.7KB |             +8.2KB |             +14.4KB |     +19.4KB |
 | net6.0         |         10.0KB |       335.8KB |  +325.8KB |   +17.7KB |             +8.7KB |              +1.6KB |      +4.2KB |
 | net7.0         |         10.0KB |       287.9KB |  +277.9KB |   +16.6KB |             +6.9KB |              +1.1KB |      +3.7KB |
-| net8.0         |          9.5KB |       244.1KB |  +234.6KB |   +15.5KB |          +299bytes |              +1.1KB |      +3.7KB |
+| net8.0         |          9.5KB |       243.6KB |  +234.1KB |   +16.0KB |          +811bytes |              +1.6KB |      +4.2KB |
 | net9.0         |          9.5KB |       167.6KB |  +158.1KB |   +15.5KB |                    |              +1.1KB |      +3.7KB |
 | net10.0        |         10.0KB |       136.1KB |  +126.1KB |   +16.0KB |                    |              +1.1KB |      +3.7KB |
 | net11.0        |         10.0KB |        30.9KB |   +20.9KB |   +16.5KB |                    |              +1.1KB |      +4.2KB |
@@ -708,14 +708,26 @@ The class `Polyfill` includes the following extension methods:
 #### BitConverter
 
  * `ulong DoubleToUInt64Bits(double)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.doubletouint64bits?view=net-11.0)
+ * `byte[] GetBytes(Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-half))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `byte[] GetBytes(Int128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-int128))
  * `byte[] GetBytes(UInt128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-uint128))
+ * `short HalfToInt16Bits(Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.halftoint16bits?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
+ * `ushort HalfToUInt16Bits(Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.halftouint16bits?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
+ * `Half Int16BitsToHalf(short)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.int16bitstohalf?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `float Int32BitsToSingle(int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.int32bitstosingle?view=net-11.0)
  * `int SingleToInt32Bits(float)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.singletoint32bits?view=net-11.0)
  * `uint SingleToUInt32Bits(float)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.singletouint32bits?view=net-11.0)
  * `bool ToBoolean(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toboolean?view=net-11.0#system-bitconverter-toboolean(system-readonlyspan((system-byte))))
  * `char ToChar(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tochar?view=net-11.0#system-bitconverter-tochar(system-readonlyspan((system-byte))))
  * `double ToDouble(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.todouble?view=net-11.0#system-bitconverter-todouble(system-readonlyspan((system-byte))))
+ * `Half ToHalf(byte[], int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tohalf?view=net-11.0#system-bitconverter-tohalf(system-byte()-system-int32))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
+ * `Half ToHalf(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tohalf?view=net-11.0#system-bitconverter-tohalf(system-readonlyspan((system-byte))))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `Int128 ToInt128(byte[], int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toint128?view=net-11.0#system-bitconverter-toint128(system-byte()-system-int32))
  * `Int128 ToInt128(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toint128?view=net-11.0#system-bitconverter-toint128(system-readonlyspan((system-byte))))
  * `short ToInt16(ReadOnlySpan<byte>)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.toint16?view=net-11.0#system-bitconverter-toint16(system-readonlyspan((system-byte))))
@@ -731,6 +743,8 @@ The class `Polyfill` includes the following extension methods:
  * `bool TryWriteBytes(Span<byte>, char)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-char))
  * `bool TryWriteBytes(Span<byte>, double)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-double))
  * `bool TryWriteBytes(Span<byte>, float)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-single))
+ * `bool TryWriteBytes(Span<byte>, Half)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-half))
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `bool TryWriteBytes(Span<byte>, int)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-int32))
  * `bool TryWriteBytes(Span<byte>, Int128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-int128))
  * `bool TryWriteBytes(Span<byte>, long)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-int64))
@@ -739,6 +753,8 @@ The class `Polyfill` includes the following extension methods:
  * `bool TryWriteBytes(Span<byte>, UInt128)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-uint128))
  * `bool TryWriteBytes(Span<byte>, ulong)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-uint64))
  * `bool TryWriteBytes(Span<byte>, ushort)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-uint16))
+ * `Half UInt16BitsToHalf(ushort)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint16bitstohalf?view=net-11.0)
+   * Note: Only available on net5.0 and later, since Half does not exist below that.
  * `float UInt32BitsToSingle(uint)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint32bitstosingle?view=net-11.0)
  * `double UInt64BitsToDouble(ulong)` [reference](https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint64bitstodouble?view=net-11.0)
 
@@ -2533,7 +2549,7 @@ void ObjectDisposedExceptionExample(bool isDisposed)
     ObjectDisposedException.ThrowIf(isDisposed, typeof(Consume));
 }
 ```
-<sup><a href='/src/Consume/Consume.cs#L904-L928' title='Snippet source file'>snippet source</a> | <a href='#snippet-ArgumentExceptionUsage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Consume/Consume.cs#L919-L943' title='Snippet source file'>snippet source</a> | <a href='#snippet-ArgumentExceptionUsage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -2552,7 +2568,7 @@ void EnsureExample(Order order, Customer customer, string customerId, string ema
     this.quantity = Ensure.NotNegativeOrZero(quantity);
 }
 ```
-<sup><a href='/src/Consume/Consume.cs#L934-L946' title='Snippet source file'>snippet source</a> | <a href='#snippet-EnsureUsage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Consume/Consume.cs#L949-L961' title='Snippet source file'>snippet source</a> | <a href='#snippet-EnsureUsage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Consume/Consume.cs
+++ b/src/Consume/Consume.cs
@@ -356,6 +356,21 @@ class Consume
     }
 #endif
 
+#if NET5_0_OR_GREATER
+    void BitConverter_Half_Methods()
+    {
+        var value = (Half) 1.5f;
+        var bytes = BitConverter.GetBytes(value);
+        var int16Bits = BitConverter.HalfToInt16Bits(value);
+        var uint16Bits = BitConverter.HalfToUInt16Bits(value);
+        value = BitConverter.Int16BitsToHalf(int16Bits);
+        value = BitConverter.UInt16BitsToHalf(uint16Bits);
+        value = BitConverter.ToHalf(bytes, 0);
+        value = BitConverter.ToHalf(bytes.AsSpan());
+        var wrote = BitConverter.TryWriteBytes(bytes.AsSpan(), value);
+    }
+#endif
+
 #if NET7_0_OR_GREATER
     void BitConverter_Int128_Methods()
     {

--- a/src/Polyfill/Polyfill_BitConverter.cs
+++ b/src/Polyfill/Polyfill_BitConverter.cs
@@ -381,6 +381,112 @@ static partial class Polyfill
 
 #endif
 
+#if NET5_0_OR_GREATER && !NET6_0_OR_GREATER
+
+        /// <summary>
+        /// Returns the specified half-precision floating point value as an array of bytes.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.getbytes?view=net-11.0#system-bitconverter-getbytes(system-half)
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static byte[] GetBytes(Half value)
+        {
+            var bytes = new byte[2];
+            MemoryMarshal.Write(bytes, ref value);
+            return bytes;
+        }
+
+        /// <summary>
+        /// Converts a half-precision floating point value into a 16-bit signed integer.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.halftoint16bits?view=net-11.0
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static short HalfToInt16Bits(Half value)
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            MemoryMarshal.Write(buffer, ref value);
+            return MemoryMarshal.Read<short>(buffer);
+        }
+
+        /// <summary>
+        /// Converts a half-precision floating point value into a 16-bit unsigned integer.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.halftouint16bits?view=net-11.0
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static ushort HalfToUInt16Bits(Half value)
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            MemoryMarshal.Write(buffer, ref value);
+            return MemoryMarshal.Read<ushort>(buffer);
+        }
+
+        /// <summary>
+        /// Reinterprets the specified 16-bit signed integer as a half-precision floating point value.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.int16bitstohalf?view=net-11.0
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static Half Int16BitsToHalf(short value)
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            MemoryMarshal.Write(buffer, ref value);
+            return MemoryMarshal.Read<Half>(buffer);
+        }
+
+        /// <summary>
+        /// Reinterprets the specified 16-bit unsigned integer as a half-precision floating point value.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.uint16bitstohalf?view=net-11.0
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static Half UInt16BitsToHalf(ushort value)
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            MemoryMarshal.Write(buffer, ref value);
+            return MemoryMarshal.Read<Half>(buffer);
+        }
+
+        /// <summary>
+        /// Returns a half-precision floating point number converted from two bytes at a specified position in a byte array.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tohalf?view=net-11.0#system-bitconverter-tohalf(system-byte()-system-int32)
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static Half ToHalf(byte[] value, int startIndex)
+        {
+            GuardTwoBytes(value, startIndex);
+            return MemoryMarshal.Read<Half>(value.AsSpan(startIndex));
+        }
+
+        /// <summary>
+        /// Converts a read-only byte span into a half-precision floating point value.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.tohalf?view=net-11.0#system-bitconverter-tohalf(system-readonlyspan((system-byte)))
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static Half ToHalf(ReadOnlySpan<byte> value)
+        {
+            if (value.Length < 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            return MemoryMarshal.Read<Half>(value);
+        }
+
+        /// <summary>
+        /// Converts a half-precision floating point value into a span of bytes.
+        /// </summary>
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.bitconverter.trywritebytes?view=net-11.0#system-bitconverter-trywritebytes(system-span((system-byte))-system-half)
+        //Note: Only available on net5.0 and later, since Half does not exist below that.
+        public static bool TryWriteBytes(Span<byte> destination, Half value)
+        {
+            if (destination.Length < 2)
+            {
+                return false;
+            }
+
+            MemoryMarshal.Write(destination, ref value);
+            return true;
+        }
+
+#endif
+
 #if NET7_0_OR_GREATER && !NET9_0_OR_GREATER
 
         /// <summary>
@@ -545,6 +651,30 @@ static partial class Polyfill
         if (value.Length < size)
         {
             throw new ArgumentOutOfRangeException(nameof(value));
+        }
+    }
+
+#endif
+
+#if NET5_0_OR_GREATER && !NET6_0_OR_GREATER
+
+    // matches the validation the BCL uses for every other BitConverter array overload
+    static void GuardTwoBytes(byte[] value, int startIndex)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        if (startIndex < 0 ||
+            startIndex >= value.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startIndex), "Index was out of range. Must be non-negative and less than the size of the collection.");
+        }
+
+        if (startIndex > value.Length - 2)
+        {
+            throw new ArgumentException("The array starting from the specified index is not long enough to read a value of the specified type.", nameof(value));
         }
     }
 

--- a/src/Split/net5.0/Polyfill_BitConverter.cs
+++ b/src/Split/net5.0/Polyfill_BitConverter.cs
@@ -41,6 +41,98 @@ static partial class Polyfill
 		{
 			return (ulong)BitConverter.DoubleToInt64Bits(value);
 		}
+		/// <summary>
+		/// Returns the specified half-precision floating point value as an array of bytes.
+		/// </summary>
+		public static byte[] GetBytes(Half value)
+		{
+			var bytes = new byte[2];
+			MemoryMarshal.Write(bytes, ref value);
+			return bytes;
+		}
+		/// <summary>
+		/// Converts a half-precision floating point value into a 16-bit signed integer.
+		/// </summary>
+		public static short HalfToInt16Bits(Half value)
+		{
+			Span<byte> buffer = stackalloc byte[2];
+			MemoryMarshal.Write(buffer, ref value);
+			return MemoryMarshal.Read<short>(buffer);
+		}
+		/// <summary>
+		/// Converts a half-precision floating point value into a 16-bit unsigned integer.
+		/// </summary>
+		public static ushort HalfToUInt16Bits(Half value)
+		{
+			Span<byte> buffer = stackalloc byte[2];
+			MemoryMarshal.Write(buffer, ref value);
+			return MemoryMarshal.Read<ushort>(buffer);
+		}
+		/// <summary>
+		/// Reinterprets the specified 16-bit signed integer as a half-precision floating point value.
+		/// </summary>
+		public static Half Int16BitsToHalf(short value)
+		{
+			Span<byte> buffer = stackalloc byte[2];
+			MemoryMarshal.Write(buffer, ref value);
+			return MemoryMarshal.Read<Half>(buffer);
+		}
+		/// <summary>
+		/// Reinterprets the specified 16-bit unsigned integer as a half-precision floating point value.
+		/// </summary>
+		public static Half UInt16BitsToHalf(ushort value)
+		{
+			Span<byte> buffer = stackalloc byte[2];
+			MemoryMarshal.Write(buffer, ref value);
+			return MemoryMarshal.Read<Half>(buffer);
+		}
+		/// <summary>
+		/// Returns a half-precision floating point number converted from two bytes at a specified position in a byte array.
+		/// </summary>
+		public static Half ToHalf(byte[] value, int startIndex)
+		{
+			GuardTwoBytes(value, startIndex);
+			return MemoryMarshal.Read<Half>(value.AsSpan(startIndex));
+		}
+		/// <summary>
+		/// Converts a read-only byte span into a half-precision floating point value.
+		/// </summary>
+		public static Half ToHalf(ReadOnlySpan<byte> value)
+		{
+			if (value.Length < 2)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value));
+			}
+			return MemoryMarshal.Read<Half>(value);
+		}
+		/// <summary>
+		/// Converts a half-precision floating point value into a span of bytes.
+		/// </summary>
+		public static bool TryWriteBytes(Span<byte> destination, Half value)
+		{
+			if (destination.Length < 2)
+			{
+				return false;
+			}
+			MemoryMarshal.Write(destination, ref value);
+			return true;
+		}
+	}
+	static void GuardTwoBytes(byte[] value, int startIndex)
+	{
+		if (value == null)
+		{
+			throw new ArgumentNullException(nameof(value));
+		}
+		if (startIndex < 0 ||
+			startIndex >= value.Length)
+		{
+			throw new ArgumentOutOfRangeException(nameof(startIndex), "Index was out of range. Must be non-negative and less than the size of the collection.");
+		}
+		if (startIndex > value.Length - 2)
+		{
+			throw new ArgumentException("The array starting from the specified index is not long enough to read a value of the specified type.", nameof(value));
+		}
 	}
 }
 #endif

--- a/src/Tests/BitConverterHalfTests.cs
+++ b/src/Tests/BitConverterHalfTests.cs
@@ -1,0 +1,157 @@
+#if NET5_0_OR_GREATER
+
+// Half is a 16 bit type, so every representable value can be checked rather than sampled.
+// Runs on net5.0 and later, so net6.0 and above validate the BCL and net5.0 the polyfill.
+public class BitConverterHalfTests
+{
+    [Test]
+    public async Task EveryBitPatternRoundTrips()
+    {
+        var failures = 0;
+        for (var i = 0; i <= ushort.MaxValue; i++)
+        {
+            var bits = (ushort) i;
+            var signedBits = unchecked((short) bits);
+
+            var value = BitConverter.UInt16BitsToHalf(bits);
+            if (BitConverter.HalfToUInt16Bits(value) != bits)
+            {
+                failures++;
+                continue;
+            }
+
+            if (BitConverter.HalfToInt16Bits(BitConverter.Int16BitsToHalf(signedBits)) != signedBits)
+            {
+                failures++;
+                continue;
+            }
+
+            // the signed and unsigned views must be the same sixteen bits
+            if (unchecked((ushort) BitConverter.HalfToInt16Bits(value)) != bits)
+            {
+                failures++;
+                continue;
+            }
+
+            var bytes = BitConverter.GetBytes(value);
+            if (bytes.Length != 2 ||
+                BitConverter.HalfToUInt16Bits(BitConverter.ToHalf(bytes, 0)) != bits ||
+                BitConverter.HalfToUInt16Bits(ToHalfSpan(bytes)) != bits)
+            {
+                failures++;
+                continue;
+            }
+
+            var written = new byte[2];
+            if (!TryWrite(written, value) ||
+                written[0] != bytes[0] ||
+                written[1] != bytes[1])
+            {
+                failures++;
+            }
+        }
+
+        await Assert.That(failures).IsEqualTo(0);
+    }
+
+    // NaN payloads, both infinities, negative zero and the subnormal boundary are the patterns
+    // a float based implementation would silently lose, so they are pinned explicitly
+    [Test]
+    public async Task NotablePatterns()
+    {
+        await Assert.That(Hex(0x0000)).IsEqualTo("0000");
+        await Assert.That(Hex(0x8000)).IsEqualTo("0080");
+        await Assert.That(Hex(0x3C00)).IsEqualTo("003c");
+        await Assert.That(Hex(0x7C00)).IsEqualTo("007c");
+        await Assert.That(Hex(0xFC00)).IsEqualTo("00fc");
+        await Assert.That(Hex(0x7E00)).IsEqualTo("007e");
+        await Assert.That(Hex(0x7C01)).IsEqualTo("017c");
+        await Assert.That(Hex(0x0001)).IsEqualTo("0100");
+        await Assert.That(Hex(0x7BFF)).IsEqualTo("ff7b");
+
+        await Assert.That(BitConverter.HalfToInt16Bits(BitConverter.UInt16BitsToHalf(0x8000))).IsEqualTo(short.MinValue);
+        await Assert.That(BitConverter.HalfToUInt16Bits(Half.NaN)).IsEqualTo((ushort) 0xFE00);
+        await Assert.That(BitConverter.HalfToUInt16Bits(Half.PositiveInfinity)).IsEqualTo((ushort) 0x7C00);
+        await Assert.That(BitConverter.HalfToUInt16Bits(Half.NegativeInfinity)).IsEqualTo((ushort) 0xFC00);
+    }
+
+    [Test]
+    public async Task ArrayArgumentValidation()
+    {
+        var four = new byte[4];
+
+        await Assert.That(Capture(() => BitConverter.ToHalf(null!, 0))).IsEqualTo("ArgumentNullException:value");
+        await Assert.That(Capture(() => BitConverter.ToHalf(four, -1))).IsEqualTo("ArgumentOutOfRangeException:startIndex");
+        await Assert.That(Capture(() => BitConverter.ToHalf(four, 4))).IsEqualTo("ArgumentOutOfRangeException:startIndex");
+
+        // in range as an index, but only one byte remains
+        await Assert.That(Capture(() => BitConverter.ToHalf(four, 3))).IsEqualTo("ArgumentException:value");
+
+        // the last position that still leaves two bytes
+        await Assert.That(Capture(() => BitConverter.ToHalf(four, 2))).IsEqualTo("none");
+    }
+
+    [Test]
+    public async Task SpanArgumentValidationAndSizing()
+    {
+        await Assert.That(Capture(() => ToHalfSpan(new byte[1]))).IsEqualTo("ArgumentOutOfRangeException:value");
+        await Assert.That(Capture(() => ToHalfSpan(new byte[2]))).IsEqualTo("none");
+        await Assert.That(Capture(() => ToHalfSpan(new byte[3]))).IsEqualTo("none");
+
+        var value = (Half) 1.5f;
+        var expected = BitConverter.GetBytes(value);
+
+        var small = Filled(1);
+        await Assert.That(TryWrite(small, value)).IsFalse();
+        await Assert.That(small[0]).IsEqualTo((byte) 0xAA);
+
+        var exact = Filled(2);
+        await Assert.That(TryWrite(exact, value)).IsTrue();
+        await Assert.That(exact[0]).IsEqualTo(expected[0]);
+        await Assert.That(exact[1]).IsEqualTo(expected[1]);
+
+        // a larger destination keeps its trailing bytes
+        var larger = Filled(3);
+        await Assert.That(TryWrite(larger, value)).IsTrue();
+        await Assert.That(larger[2]).IsEqualTo((byte) 0xAA);
+    }
+
+    static byte[] Filled(int size)
+    {
+        var buffer = new byte[size];
+        for (var i = 0; i < size; i++)
+        {
+            buffer[i] = 0xAA;
+        }
+
+        return buffer;
+    }
+
+    // the spans stay inside these helpers, so nothing ref struct shaped lives across an await
+    static Half ToHalfSpan(byte[] buffer) =>
+        BitConverter.ToHalf(buffer.AsSpan());
+
+    static bool TryWrite(byte[] buffer, Half value) =>
+        BitConverter.TryWriteBytes(buffer, value);
+
+    static string Hex(int bits)
+    {
+        var bytes = BitConverter.GetBytes(BitConverter.UInt16BitsToHalf((ushort) bits));
+        return bytes[0].ToString("x2") + bytes[1].ToString("x2");
+    }
+
+    static string Capture(Action action)
+    {
+        try
+        {
+            action();
+            return "none";
+        }
+        catch (ArgumentException exception)
+        {
+            return $"{exception.GetType().Name}:{exception.ParamName}";
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Eight members: `GetBytes(Half)`, `HalfToInt16Bits`, `HalfToUInt16Bits`, `Int16BitsToHalf`, `UInt16BitsToHalf`, `ToHalf` over an array and over a span, and `TryWriteBytes(Span<byte>, Half)`.

### The window really is net5.0 alone

I flagged this as poor value in #598 and should be precise about why, because it is narrower than it looks:

* `Half` the **type** is net5.0.
* Every one of these BitConverter **members** is net6.0 — confirmed absent from the 5.0.0 ref pack and present in 6.0.36.

So below net5.0 there is nothing to convert, and from net6.0 the BCL supplies them. One target framework. Each member carries a `//Note:` saying so, the same way the `Int128` members do, since the `#### BitConverter` section header gives no hint of a floor.

Narrow, but the value is real for anyone still on net5.0: today they have no way to get at a `Half`'s bits at all, because the type deliberately exposes none.

### Reinterpretation, not conversion

The obvious shortcut — round through `float` — silently destroys NaN payloads and would produce a canonical NaN for every one of the 2046 distinct NaN encodings. So the bits go through `MemoryMarshal` over a two-byte stack buffer, which is exact and allocation-free (`GetBytes` allocates its 2-byte array, as the BCL does). No unsafe code and no dependency on `Unsafe`.

Endianness cancels out for the `*Bits*` members: writing a `Half` in platform order and reading a `short` back in platform order yields the same sixteen bits either way.

### Verified exhaustively

`Half` is 16 bits, so this does not need sampling. All **65 536** patterns were swept against the BCL before the code was written, and the shipped tests do the same sweep: every pattern round trips, and `GetBytes`, `ToHalf` and `TryWriteBytes` agree with the BCL byte for byte. Zero mismatches, including every NaN payload, both infinities, negative zero, and the subnormal boundary. Nine notable patterns are also pinned explicitly, so a regression names the case rather than just a count.

Argument validation matches the array overloads already on the type — `ArgumentNullException` on null, `ArgumentOutOfRangeException` on `startIndex` outside the array, and `ArgumentException` naming `value` when the index is in range but only one byte remains.

### How the polyfill was actually exercised

This is the awkward part, and worth stating plainly: the polyfill compiles **only** on net5.0, and that runtime is not installed on this machine, so a normal test run would have exercised the BCL and never the polyfill.

So the net5.0 test build was run against the net11 runtime with `dotnet exec --roll-forward LatestMajor`. That build **compiling at all** already proves the polyfill is doing the work — net5.0 has none of these members, so without it there would be nothing to bind to — and all **1655** tests pass there, including the exhaustive sweep. CI, which has the net5.0 runtime, will run it natively.

### Result

API count 1139 → 1147.

Solution clean in Release, Consume clean across all 22 TFMs, tests green on net11.0 (1714), net10.0 (1714), net9.0 (1714), net8.0 (1711), net462 (1665), net5.0 via roll-forward (1655), plus PublicTests, EmbeddedTests, UnsafeTests, NoRefsTests and NoExtrasTests.
